### PR TITLE
feat: replace all IPC channels with NATS

### DIFF
--- a/py/container/Dockerfile
+++ b/py/container/Dockerfile
@@ -18,8 +18,9 @@ RUN pip install --no-cache-dir claude-agent-sdk croniter nats-py
 # Create app directory
 WORKDIR /app
 
-# Copy agent runner code
+# Copy agent runner code and shared IPC protocol
 COPY src/agent_runner/ ./agent_runner/
+COPY src/nanoclaw/ipc/protocol.py ./nanoclaw_ipc_protocol.py
 
 # Create workspace directories (no IPC dirs needed — all IPC goes through NATS)
 RUN mkdir -p /workspace/group /workspace/global /workspace/extra

--- a/py/container/Dockerfile
+++ b/py/container/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python agent SDK (bundles Claude Code CLI)
-RUN pip install --no-cache-dir claude-agent-sdk croniter
+RUN pip install --no-cache-dir claude-agent-sdk croniter nats-py
 
 # Create app directory
 WORKDIR /app
@@ -21,9 +21,8 @@ WORKDIR /app
 # Copy agent runner code
 COPY src/agent_runner/ ./agent_runner/
 
-# Create workspace directories
-RUN mkdir -p /workspace/group /workspace/global /workspace/extra \
-    /workspace/ipc/messages /workspace/ipc/tasks /workspace/ipc/input
+# Create workspace directories (no IPC dirs needed — all IPC goes through NATS)
+RUN mkdir -p /workspace/group /workspace/global /workspace/extra
 
 # Create non-root user for sandbox
 RUN useradd -m -s /bin/bash agent || true
@@ -38,5 +37,5 @@ ENV PYTHONPATH=/app
 # Set working directory to group workspace
 WORKDIR /workspace/group
 
-# Entry point reads JSON from stdin, outputs JSON to stdout
+# Entry point reads config from NATS KV, outputs results via NATS JetStream
 ENTRYPOINT ["python", "-m", "agent_runner"]

--- a/py/docker-compose.dev.yml
+++ b/py/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+services:
+  nats:
+    image: nats:latest
+    ports:
+      - "4222:4222"   # Client
+      - "8222:8222"   # Monitoring
+    command: ["--jetstream", "--store_dir=/data"]
+    volumes:
+      - nats-data:/data
+
+volumes:
+  nats-data:

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "aiohttp>=3.9",
     "python-telegram-bot>=22.7",
     "slack-bolt>=1.27.0",
+    "nats-py>=2.9",
 ]
 
 [project.scripts]

--- a/py/src/agent_runner/ipc_mcp.py
+++ b/py/src/agent_runner/ipc_mcp.py
@@ -1,37 +1,24 @@
 """
 NanoClaw in-process MCP server.
 
-Defines MCP tools that write IPC files for the host process to consume.
+Defines MCP tools that publish to NATS for the host process to consume.
 Uses create_sdk_mcp_server / @tool for in-process registration (no stdio).
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import time
 from datetime import datetime
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from claude_agent_sdk import create_sdk_mcp_server, tool
 from croniter import croniter
 
-IPC_DIR = Path("/workspace/ipc")
-MESSAGES_DIR = IPC_DIR / "messages"
-TASKS_DIR = IPC_DIR / "tasks"
-
-
-def _write_ipc_file(directory: Path, data: dict[str, Any]) -> str:
-    """Atomically write a JSON IPC file and return the filename."""
-    directory.mkdir(parents=True, exist_ok=True)
-    rand_suffix = f"{time.time_ns() % 10**8:08x}"
-    filename = f"{int(time.time() * 1000)}-{rand_suffix}.json"
-    filepath = directory / filename
-    temp_path = filepath.with_suffix(".json.tmp")
-    temp_path.write_text(json.dumps(data, indent=2))
-    temp_path.rename(filepath)
-    return filename
+if TYPE_CHECKING:
+    from nats.js.client import JetStreamContext
 
 
 def _text_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
@@ -46,8 +33,20 @@ def create_nanoclaw_mcp_server(
     chat_jid: str,
     group_folder: str,
     is_main: bool,
+    js: JetStreamContext,
+    job_id: str,
 ) -> Any:
     """Create and return an in-process MCP server with all NanoClaw tools."""
+
+    _bg_tasks: set[asyncio.Task[None]] = set()
+
+    def _publish(subject: str, data: dict[str, Any]) -> None:
+        """Publish a JSON message to NATS JetStream (fire-and-forget)."""
+        task = asyncio.ensure_future(
+            js.publish(subject, json.dumps(data, indent=2).encode())  # type: ignore[arg-type]
+        )
+        _bg_tasks.add(task)
+        task.add_done_callback(_bg_tasks.discard)
 
     # --- send_message ---
     @tool(
@@ -66,7 +65,7 @@ def create_nanoclaw_mcp_server(
         }
         if args.get("sender"):
             data["sender"] = args["sender"]
-        _write_ipc_file(MESSAGES_DIR, data)
+        _publish(f"agent.{job_id}.messages", data)
         return _text_result("Message sent.")
 
     # --- schedule_task ---
@@ -125,8 +124,8 @@ def create_nanoclaw_mcp_server(
         rand_suffix = f"{time.time_ns() % 10**8:08x}"
         task_id = f"task-{int(time.time() * 1000)}-{rand_suffix}"
 
-        _write_ipc_file(
-            TASKS_DIR,
+        _publish(
+            f"agent.{job_id}.tasks",
             {
                 "type": "schedule_task",
                 "taskId": task_id,
@@ -136,6 +135,7 @@ def create_nanoclaw_mcp_server(
                 "context_mode": context_mode or "group",
                 "targetJid": target_jid,
                 "createdBy": group_folder,
+                "groupFolder": group_folder,
                 "timestamp": datetime.now().isoformat(),
             },
         )
@@ -144,11 +144,10 @@ def create_nanoclaw_mcp_server(
     # --- list_tasks ---
     @tool("list_tasks", "List all scheduled tasks.", {})
     async def list_tasks(args: dict[str, Any]) -> dict[str, Any]:
-        tasks_file = IPC_DIR / "current_tasks.json"
         try:
-            if not tasks_file.exists():
-                return _text_result("No scheduled tasks found.")
-            all_tasks: list[dict[str, Any]] = json.loads(tasks_file.read_text())
+            kv = await js.key_value("snapshots")
+            entry = await kv.get(f"{group_folder}.tasks")
+            all_tasks: list[dict[str, Any]] = json.loads(entry.value)
             tasks = all_tasks if is_main else [t for t in all_tasks if t.get("groupFolder") == group_folder]
             if not tasks:
                 return _text_result("No scheduled tasks found.")
@@ -166,8 +165,8 @@ def create_nanoclaw_mcp_server(
     @tool("pause_task", "Pause a scheduled task.", {"task_id": str})
     async def pause_task(args: dict[str, Any]) -> dict[str, Any]:
         task_id = args["task_id"]
-        _write_ipc_file(
-            TASKS_DIR,
+        _publish(
+            f"agent.{job_id}.tasks",
             {
                 "type": "pause_task",
                 "taskId": task_id,
@@ -182,8 +181,8 @@ def create_nanoclaw_mcp_server(
     @tool("resume_task", "Resume a paused task.", {"task_id": str})
     async def resume_task(args: dict[str, Any]) -> dict[str, Any]:
         task_id = args["task_id"]
-        _write_ipc_file(
-            TASKS_DIR,
+        _publish(
+            f"agent.{job_id}.tasks",
             {
                 "type": "resume_task",
                 "taskId": task_id,
@@ -198,8 +197,8 @@ def create_nanoclaw_mcp_server(
     @tool("cancel_task", "Cancel and delete a scheduled task.", {"task_id": str})
     async def cancel_task(args: dict[str, Any]) -> dict[str, Any]:
         task_id = args["task_id"]
-        _write_ipc_file(
-            TASKS_DIR,
+        _publish(
+            f"agent.{job_id}.tasks",
             {
                 "type": "cancel_task",
                 "taskId": task_id,
@@ -248,7 +247,7 @@ def create_nanoclaw_mcp_server(
         if sval is not None:
             data["schedule_value"] = sval
 
-        _write_ipc_file(TASKS_DIR, data)
+        _publish(f"agent.{job_id}.tasks", data)
         return _text_result(f"Task {task_id} update requested.")
 
     # --- register_group ---
@@ -260,14 +259,15 @@ def create_nanoclaw_mcp_server(
     async def register_group(args: dict[str, Any]) -> dict[str, Any]:
         if not is_main:
             return _text_result("Only the main group can register new groups.", is_error=True)
-        _write_ipc_file(
-            TASKS_DIR,
+        _publish(
+            f"agent.{job_id}.tasks",
             {
                 "type": "register_group",
                 "jid": args["jid"],
                 "name": args["name"],
                 "folder": args["folder"],
                 "trigger": args["trigger"],
+                "groupFolder": group_folder,
                 "timestamp": datetime.now().isoformat(),
             },
         )

--- a/py/src/agent_runner/ipc_mcp.py
+++ b/py/src/agent_runner/ipc_mcp.py
@@ -275,5 +275,5 @@ def create_nanoclaw_mcp_server(
 
     return create_sdk_mcp_server(
         "nanoclaw",
-        [send_message, schedule_task, list_tasks, pause_task, resume_task, cancel_task, update_task, register_group],
+        tools=[send_message, schedule_task, list_tasks, pause_task, resume_task, cancel_task, update_task, register_group],
     )

--- a/py/src/agent_runner/main.py
+++ b/py/src/agent_runner/main.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 import nats
 from claude_agent_sdk import ClaudeAgentOptions, HookMatcher, query
+from nanoclaw_ipc_protocol import AgentInitData
 
 from .ipc_mcp import create_nanoclaw_mcp_server
 
@@ -570,15 +571,15 @@ async def main() -> None:
     try:
         kv = await js.key_value("agent-init")
         entry = await kv.get(JOB_ID)
-        raw = json.loads(entry.value)
+        init = AgentInitData.deserialize(entry.value)
         container_input = ContainerInput(
-            prompt=raw["prompt"],
-            group_folder=raw["group_folder"],
-            chat_jid=raw["chat_jid"],
-            is_main=raw["is_main"],
-            session_id=raw.get("session_id"),
-            is_scheduled_task=raw.get("is_scheduled_task", False),
-            assistant_name=raw.get("assistant_name"),
+            prompt=init.prompt,
+            group_folder=init.group_folder,
+            chat_jid=init.chat_jid,
+            is_main=init.is_main,
+            session_id=init.session_id,
+            is_scheduled_task=init.is_scheduled_task,
+            assistant_name=init.assistant_name,
         )
         log(f"Received input for group: {container_input.group_folder}")
     except (OSError, json.JSONDecodeError, KeyError, ValueError, RuntimeError) as exc:

--- a/py/src/agent_runner/main.py
+++ b/py/src/agent_runner/main.py
@@ -1,18 +1,16 @@
 """
 NanoClaw Agent Runner (Python)
 
-Runs inside a Docker container, receives config via stdin, outputs result to stdout.
+Runs inside a Docker container with NATS-based IPC.
 
 Input protocol:
-  Stdin: Full ContainerInput JSON (read until EOF)
-  IPC:   Follow-up messages written as JSON files to /workspace/ipc/input/
-         Files: {type:"message", text:"..."}.json -- polled and consumed
-         Sentinel: /workspace/ipc/input/_close -- signals session end
+  NATS KV: Reads initial config from KV bucket "agent-init" key JOB_ID
+  NATS JetStream: Follow-up messages via agent.{JOB_ID}.input
+  NATS request-reply: Close signal via agent.{JOB_ID}.close
 
-Stdout protocol:
-  Each result is wrapped in OUTPUT_START_MARKER / OUTPUT_END_MARKER pairs.
-  Multiple results may be emitted (one per agent teams result).
-  Final marker after loop ends signals completion.
+Output protocol:
+  NATS JetStream: Results published to agent.{JOB_ID}.results
+  NATS JetStream: Messages and tasks via agent.{JOB_ID}.messages / .tasks
 """
 
 from __future__ import annotations
@@ -20,18 +18,23 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import nats
 from claude_agent_sdk import ClaudeAgentOptions, HookMatcher, query
 
 from .ipc_mcp import create_nanoclaw_mcp_server
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+    from nats.aio.client import Client
+    from nats.js.client import JetStreamContext
 
 # ---------------------------------------------------------------------------
 # Types
@@ -83,12 +86,8 @@ class ParsedMessage:
 # Constants
 # ---------------------------------------------------------------------------
 
-IPC_INPUT_DIR = Path("/workspace/ipc/input")
-IPC_INPUT_CLOSE_SENTINEL = IPC_INPUT_DIR / "_close"
-IPC_POLL_SECONDS = 0.5
-
-OUTPUT_START_MARKER = "---NANOCLAW_OUTPUT_START---"
-OUTPUT_END_MARKER = "---NANOCLAW_OUTPUT_END---"
+NATS_URL = os.environ.get("NATS_URL", "nats://localhost:4222")
+JOB_ID = os.environ.get("JOB_ID", "")
 
 
 # ---------------------------------------------------------------------------
@@ -135,13 +134,6 @@ class MessageStream:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def write_output(output: ContainerOutput) -> None:
-    print(OUTPUT_START_MARKER)
-    print(json.dumps(output.to_dict()))
-    print(OUTPUT_END_MARKER)
-    sys.stdout.flush()
 
 
 def log(message: str) -> None:
@@ -282,49 +274,80 @@ def create_pre_compact_hook(
 
 
 # ---------------------------------------------------------------------------
-# IPC polling helpers
+# NATS helpers for IPC
 # ---------------------------------------------------------------------------
 
 
-def should_close() -> bool:
-    if IPC_INPUT_CLOSE_SENTINEL.exists():
-        with contextlib.suppress(OSError):
-            IPC_INPUT_CLOSE_SENTINEL.unlink()
-        return True
-    return False
+async def publish_output(js: JetStreamContext, job_id: str, output: ContainerOutput) -> None:
+    """Publish a result to JetStream (Channel 2)."""
+    await js.publish(
+        f"agent.{job_id}.results",
+        json.dumps(output.to_dict()).encode(),
+    )
 
 
-def drain_ipc_input() -> list[str]:
+async def wait_for_nats_message(
+    nc: Client,
+    js: JetStreamContext,
+    job_id: str,
+) -> str | None:
+    """Wait for a new NATS input message or close signal.
+
+    Returns the message text, or None if close signal received.
+    """
+    result_text: str | None = None
+    close_received = asyncio.Event()
+    message_received = asyncio.Event()
+
+    # Subscribe to follow-up messages (Channel 3)
+    input_sub = await js.subscribe(f"agent.{job_id}.input")
+
+    # Subscribe to close signal (Channel 3 - request-reply)
+    async def handle_close(msg: Any) -> None:
+        await msg.respond(b"ack")
+        close_received.set()
+
+    close_sub = await nc.subscribe(f"agent.{job_id}.close", cb=handle_close)
+
     try:
-        IPC_INPUT_DIR.mkdir(parents=True, exist_ok=True)
-        files = sorted(f for f in IPC_INPUT_DIR.iterdir() if f.suffix == ".json")
-
-        messages: list[str] = []
-        for filepath in files:
+        while True:
+            # Check for input messages
             try:
-                data = json.loads(filepath.read_text())
-                filepath.unlink()
+                msg = await asyncio.wait_for(input_sub.next_msg(timeout=0.5), timeout=0.5)
+                data = json.loads(msg.data)
+                await msg.ack()
+                if data.get("type") == "message" and data.get("text"):
+                    result_text = data["text"]
+                    message_received.set()
+            except TimeoutError:
+                pass
+
+            if close_received.is_set():
+                return None
+            if message_received.is_set():
+                return result_text
+    finally:
+        await input_sub.unsubscribe()
+        await close_sub.unsubscribe()
+
+
+async def drain_nats_input(js: JetStreamContext, job_id: str) -> list[str]:
+    """Drain any pending input messages from NATS."""
+    messages: list[str] = []
+    sub = await js.subscribe(f"agent.{job_id}.input")
+    try:
+        while True:
+            try:
+                msg = await asyncio.wait_for(sub.next_msg(timeout=0.1), timeout=0.1)
+                data = json.loads(msg.data)
+                await msg.ack()
                 if data.get("type") == "message" and data.get("text"):
                     messages.append(data["text"])
-            except (OSError, json.JSONDecodeError, KeyError, ValueError, RuntimeError) as exc:
-                log(f"Failed to process input file {filepath.name}: {exc}")
-                with contextlib.suppress(OSError):
-                    filepath.unlink()
-        return messages
-    except (OSError, json.JSONDecodeError, KeyError, ValueError, RuntimeError) as exc:
-        log(f"IPC drain error: {exc}")
-        return []
-
-
-async def wait_for_ipc_message() -> str | None:
-    """Wait for a new IPC message or _close sentinel."""
-    while True:
-        if should_close():
-            return None
-        messages = drain_ipc_input()
-        if messages:
-            return "\n".join(messages)
-        await asyncio.sleep(IPC_POLL_SECONDS)
+            except TimeoutError:
+                break
+    finally:
+        await sub.unsubscribe()
+    return messages
 
 
 # ---------------------------------------------------------------------------
@@ -345,6 +368,9 @@ async def run_query(
     mcp_server: Any,
     container_input: ContainerInput,
     sdk_env: dict[str, str | None],
+    nc: Client,
+    js: JetStreamContext,
+    job_id: str,
     resume_at: str | None = None,
 ) -> QueryResult:
     stream = MessageStream()
@@ -353,20 +379,37 @@ async def run_query(
     result = QueryResult()
     ipc_polling = True
 
-    async def poll_ipc_during_query() -> None:
+    # Subscribe to close signal
+    close_received = asyncio.Event()
+
+    async def handle_close(msg: Any) -> None:
+        await msg.respond(b"ack")
+        close_received.set()
+
+    close_sub = await nc.subscribe(f"agent.{job_id}.close", cb=handle_close)
+
+    # Subscribe to follow-up input messages
+    input_sub = await js.subscribe(f"agent.{job_id}.input")
+
+    async def poll_nats_during_query() -> None:
         nonlocal ipc_polling
         while ipc_polling:
-            if should_close():
-                log("Close sentinel detected during query, ending stream")
+            if close_received.is_set():
+                log("Close signal detected during query, ending stream")
                 result.closed_during_query = True
                 stream.end()
                 ipc_polling = False
                 return
-            messages = drain_ipc_input()
-            for text in messages:
-                log(f"Piping IPC message into active query ({len(text)} chars)")
-                stream.push(text)
-            await asyncio.sleep(IPC_POLL_SECONDS)
+            try:
+                msg = await asyncio.wait_for(input_sub.next_msg(timeout=0.5), timeout=0.5)
+                data = json.loads(msg.data)
+                await msg.ack()
+                if data.get("type") == "message" and data.get("text"):
+                    text = data["text"]
+                    log(f"Piping NATS message into active query ({len(text)} chars)")
+                    stream.push(text)
+            except TimeoutError:
+                pass
 
     # Load global CLAUDE.md as additional system context (shared across all groups)
     global_claude_md_path = Path("/workspace/global/CLAUDE.md")
@@ -439,14 +482,13 @@ async def run_query(
     message_count = 0
     result_count = 0
 
-    # Start IPC polling as a background task (not in the same task group as query)
-    poll_task = asyncio.ensure_future(poll_ipc_during_query())
+    # Start NATS polling as a background task
+    poll_task = asyncio.ensure_future(poll_nats_during_query())
 
     try:
         async for message in query(prompt=stream, options=options):
             message_count += 1
 
-            # Determine message type from the object class name
             cls_name = type(message).__name__
             log_type = cls_name
 
@@ -481,21 +523,25 @@ async def run_query(
                     result.new_session_id = session_id_from_result
                 preview = text_result[:200] if text_result else ""
                 log(f"Result #{result_count}: subtype={subtype}{f' text={preview}' if text_result else ''}")
-                write_output(
+                await publish_output(
+                    js,
+                    job_id,
                     ContainerOutput(
                         status="success",
                         result=text_result or None,
                         new_session_id=result.new_session_id,
-                    )
+                    ),
                 )
 
             log(f"[msg #{message_count}] type={log_type}")
     finally:
-        # Stop IPC polling once the query iterator ends
+        # Stop NATS polling once the query iterator ends
         ipc_polling = False
         poll_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await poll_task
+        await input_sub.unsubscribe()
+        await close_sub.unsubscribe()
 
     log(
         f"Query done. Messages: {message_count}, results: {result_count}, "
@@ -511,36 +557,45 @@ async def run_query(
 
 
 async def main() -> None:
-    # Read ContainerInput JSON from stdin
+    if not JOB_ID:
+        log("JOB_ID environment variable not set")
+        sys.exit(1)
+
+    # Connect to NATS
+    nc = await nats.connect(NATS_URL)
+    js = nc.jetstream()
+    log(f"Connected to NATS at {NATS_URL}")
+
+    # Channel 1: Read initial input from KV
     try:
-        stdin_data = sys.stdin.read()
-        raw = json.loads(stdin_data)
+        kv = await js.key_value("agent-init")
+        entry = await kv.get(JOB_ID)
+        raw = json.loads(entry.value)
         container_input = ContainerInput(
             prompt=raw["prompt"],
-            group_folder=raw["groupFolder"],
-            chat_jid=raw["chatJid"],
-            is_main=raw["isMain"],
-            session_id=raw.get("sessionId"),
-            is_scheduled_task=raw.get("isScheduledTask", False),
-            assistant_name=raw.get("assistantName"),
+            group_folder=raw["group_folder"],
+            chat_jid=raw["chat_jid"],
+            is_main=raw["is_main"],
+            session_id=raw.get("session_id"),
+            is_scheduled_task=raw.get("is_scheduled_task", False),
+            assistant_name=raw.get("assistant_name"),
         )
-        with contextlib.suppress(OSError):
-            Path("/tmp/input.json").unlink()
         log(f"Received input for group: {container_input.group_folder}")
     except (OSError, json.JSONDecodeError, KeyError, ValueError, RuntimeError) as exc:
-        write_output(
+        log(f"Failed to read initial input from NATS KV: {exc}")
+        await publish_output(
+            js,
+            JOB_ID,
             ContainerOutput(
                 status="error",
                 result=None,
-                error=f"Failed to parse input: {exc}",
-            )
+                error=f"Failed to read input from NATS KV: {exc}",
+            ),
         )
+        await nc.close()
         sys.exit(1)
 
     # Credentials are injected by the host's credential proxy via ANTHROPIC_BASE_URL.
-    # No real secrets exist in the container environment.
-    import os
-
     sdk_env: dict[str, str | None] = dict(os.environ)
 
     # Create in-process MCP server
@@ -548,28 +603,25 @@ async def main() -> None:
         chat_jid=container_input.chat_jid,
         group_folder=container_input.group_folder,
         is_main=container_input.is_main,
+        js=js,
+        job_id=JOB_ID,
     )
 
     session_id = container_input.session_id
-    IPC_INPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Clean up stale _close sentinel from previous container runs
-    with contextlib.suppress(OSError):
-        IPC_INPUT_CLOSE_SENTINEL.unlink()
-
-    # Build initial prompt (drain any pending IPC messages too)
+    # Build initial prompt (drain any pending NATS messages too)
     prompt = container_input.prompt
     if container_input.is_scheduled_task:
         prompt = (
             "[SCHEDULED TASK - The following message was sent automatically "
             "and is not coming directly from the user or group.]\n\n" + prompt
         )
-    pending = drain_ipc_input()
+    pending = await drain_nats_input(js, JOB_ID)
     if pending:
-        log(f"Draining {len(pending)} pending IPC messages into initial prompt")
+        log(f"Draining {len(pending)} pending NATS messages into initial prompt")
         prompt += "\n" + "\n".join(pending)
 
-    # Query loop: run query -> wait for IPC message -> run new query -> repeat
+    # Query loop: run query -> wait for NATS message -> run new query -> repeat
     resume_at: str | None = None
     try:
         while True:
@@ -581,6 +633,9 @@ async def main() -> None:
                 mcp_server,
                 container_input,
                 sdk_env,
+                nc,
+                js,
+                JOB_ID,
                 resume_at,
             )
             if query_result.new_session_id:
@@ -588,26 +643,28 @@ async def main() -> None:
             if query_result.last_assistant_uuid:
                 resume_at = query_result.last_assistant_uuid
 
-            # If _close was consumed during the query, exit immediately.
+            # If close was consumed during the query, exit immediately.
             if query_result.closed_during_query:
-                log("Close sentinel consumed during query, exiting")
+                log("Close signal consumed during query, exiting")
                 break
 
             # Emit session update so host can track it
-            write_output(
+            await publish_output(
+                js,
+                JOB_ID,
                 ContainerOutput(
                     status="success",
                     result=None,
                     new_session_id=session_id,
-                )
+                ),
             )
 
-            log("Query ended, waiting for next IPC message...")
+            log("Query ended, waiting for next NATS message...")
 
-            # Wait for the next message or _close sentinel
-            next_message = await wait_for_ipc_message()
+            # Wait for the next message or close signal
+            next_message = await wait_for_nats_message(nc, js, JOB_ID)
             if next_message is None:
-                log("Close sentinel received, exiting")
+                log("Close signal received, exiting")
                 break
 
             log(f"Got new message ({len(next_message)} chars), starting new query")
@@ -615,12 +672,17 @@ async def main() -> None:
     except (OSError, json.JSONDecodeError, KeyError, ValueError, RuntimeError) as exc:
         error_message = str(exc)
         log(f"Agent error: {error_message}")
-        write_output(
+        await publish_output(
+            js,
+            JOB_ID,
             ContainerOutput(
                 status="error",
                 result=None,
                 new_session_id=session_id,
                 error=error_message,
-            )
+            ),
         )
+        await nc.close()
         sys.exit(1)
+
+    await nc.close()

--- a/py/src/nanoclaw/container/runner.py
+++ b/py/src/nanoclaw/container/runner.py
@@ -39,6 +39,7 @@ from nanoclaw.core.config import (
 )
 from nanoclaw.core.group_folder import resolve_group_folder_path
 from nanoclaw.core.logger import get_logger
+from nanoclaw.ipc.protocol import AgentInitData
 from nanoclaw.security.credential_proxy import detect_auth_mode
 from nanoclaw.security.mount_security import validate_additional_mounts
 
@@ -338,24 +339,22 @@ async def run_container_agent(
     # Channel 1: Write initial input to KV before starting container
     if transport is not None:
         kv_init = await transport.js.key_value("agent-init")
-        init_data = json.dumps(
-            {
-                "prompt": inp.prompt,
-                "group_folder": inp.group_folder,
-                "chat_jid": inp.chat_jid,
-                "is_main": inp.is_main,
-                "session_id": inp.session_id,
-                "is_scheduled_task": inp.is_scheduled_task,
-                "assistant_name": inp.assistant_name,
-            }
-        ).encode()
-        await kv_init.put(job_id, init_data)
+        agent_init = AgentInitData(
+            prompt=inp.prompt,
+            group_folder=inp.group_folder,
+            chat_jid=inp.chat_jid,
+            is_main=inp.is_main,
+            session_id=inp.session_id,
+            is_scheduled_task=inp.is_scheduled_task,
+            assistant_name=inp.assistant_name,
+        )
+        await kv_init.put(job_id, agent_init.serialize())
 
     proc = await asyncio.create_subprocess_exec(
         CONTAINER_RUNTIME_BIN,
         *container_args,
         stdin=asyncio.subprocess.DEVNULL,
-        stdout=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
     )
 

--- a/py/src/nanoclaw/container/runner.py
+++ b/py/src/nanoclaw/container/runner.py
@@ -1,6 +1,7 @@
-"""Container spawning and JSON I/O protocol.
+"""Container spawning with NATS-based IPC.
 
-Spawns agent execution in containers and handles streaming output parsing.
+Spawns agent execution in containers. All communication between the
+Orchestrator and Agent happens over NATS (KV + JetStream + request-reply).
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import os
 import re
 import shutil
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
@@ -31,10 +33,11 @@ from nanoclaw.core.config import (
     DATA_DIR,
     GROUPS_DIR,
     IDLE_TIMEOUT,
+    NATS_URL,
     PROJECT_ROOT,
     TIMEZONE,
 )
-from nanoclaw.core.group_folder import resolve_group_folder_path, resolve_group_ipc_path
+from nanoclaw.core.group_folder import resolve_group_folder_path
 from nanoclaw.core.logger import get_logger
 from nanoclaw.security.credential_proxy import detect_auth_mode
 from nanoclaw.security.mount_security import validate_additional_mounts
@@ -43,17 +46,14 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from nanoclaw.core.types import RegisteredGroup
+    from nanoclaw.ipc.nats_transport import NatsTransport
 
 logger = get_logger()
-
-# Sentinel markers for robust output parsing (must match agent-runner)
-OUTPUT_START_MARKER: str = "---NANOCLAW_OUTPUT_START---"
-OUTPUT_END_MARKER: str = "---NANOCLAW_OUTPUT_END---"
 
 
 @dataclass
 class ContainerInput:
-    """Input payload sent to the container agent via stdin."""
+    """Input payload for the container agent."""
 
     prompt: str
     group_folder: str
@@ -93,26 +93,6 @@ class AvailableGroup:
     is_registered: bool
 
 
-def _serialize_container_input(inp: ContainerInput) -> dict[str, object]:
-    """Serialize ContainerInput to a JSON-compatible dict using camelCase keys.
-
-    Matches the TypeScript interface expected by the container agent-runner.
-    """
-    d: dict[str, object] = {
-        "prompt": inp.prompt,
-        "groupFolder": inp.group_folder,
-        "chatJid": inp.chat_jid,
-        "isMain": inp.is_main,
-    }
-    if inp.session_id is not None:
-        d["sessionId"] = inp.session_id
-    if inp.is_scheduled_task:
-        d["isScheduledTask"] = inp.is_scheduled_task
-    if inp.assistant_name is not None:
-        d["assistantName"] = inp.assistant_name
-    return d
-
-
 def _parse_container_output(raw: dict[str, object]) -> ContainerOutput:
     """Parse a raw JSON dict into a ContainerOutput, handling camelCase keys."""
     result_val = raw.get("result")
@@ -140,10 +120,7 @@ def build_volume_mounts(
 
     if is_main:
         # Main gets the project root read-only. Writable paths the agent needs
-        # (group folder, IPC, .claude/) are mounted separately below.
-        # Read-only prevents the agent from modifying host application code
-        # (src/, dist/, package.json, etc.) which would bypass the sandbox
-        # entirely on next restart.
+        # (group folder, .claude/) are mounted separately below.
         mounts.append(
             VolumeMount(
                 host_path=str(project_root),
@@ -153,7 +130,6 @@ def build_volume_mounts(
         )
 
         # Shadow .env so the agent cannot read secrets from the mounted project root.
-        # Credentials are injected by the credential proxy, never exposed to containers.
         env_file = project_root / ".env"
         if env_file.exists():
             mounts.append(
@@ -183,7 +159,6 @@ def build_volume_mounts(
         )
 
         # Global memory directory (read-only for non-main)
-        # Only directory mounts are supported, not file mounts
         global_dir = GROUPS_DIR / "global"
         if global_dir.exists():
             mounts.append(
@@ -195,7 +170,6 @@ def build_volume_mounts(
             )
 
     # Per-group Claude sessions directory (isolated from other groups)
-    # Each group gets their own .claude/ to prevent cross-group session access
     group_sessions_dir = DATA_DIR / "sessions" / group.folder / ".claude"
     group_sessions_dir.mkdir(parents=True, exist_ok=True)
     settings_file = group_sessions_dir / "settings.json"
@@ -204,11 +178,8 @@ def build_volume_mounts(
             json.dumps(
                 {
                     "env": {
-                        # Enable agent swarms (subagent orchestration)
                         "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-                        # Load CLAUDE.md from additional mounted directories
                         "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
-                        # Enable Claude's memory feature
                         "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0",
                     },
                 },
@@ -236,23 +207,7 @@ def build_volume_mounts(
         )
     )
 
-    # Per-group IPC namespace: each group gets its own IPC directory
-    # This prevents cross-group privilege escalation via IPC
-    group_ipc_dir = resolve_group_ipc_path(group.folder)
-    (group_ipc_dir / "messages").mkdir(parents=True, exist_ok=True)
-    (group_ipc_dir / "tasks").mkdir(parents=True, exist_ok=True)
-    (group_ipc_dir / "input").mkdir(parents=True, exist_ok=True)
-    mounts.append(
-        VolumeMount(
-            host_path=str(group_ipc_dir),
-            container_path="/workspace/ipc",
-            readonly=False,
-        )
-    )
-
-    # Python agent-runner is baked into the container image (no per-group source mount needed).
-    # TS version mounted source for per-group customization + runtime compilation;
-    # Python runs directly from /app/agent_runner/ in the image.
+    # No IPC directory mount needed — all communication goes through NATS.
 
     # Additional mounts validated against external allowlist (tamper-proof from containers)
     if group.container_config and group.container_config.additional_mounts:
@@ -276,6 +231,7 @@ def build_volume_mounts(
 def build_container_args(
     mounts: list[VolumeMount],
     container_name: str,
+    job_id: str,
 ) -> list[str]:
     """Build the CLI arguments for the container runtime.
 
@@ -286,6 +242,11 @@ def build_container_args(
     # Pass host timezone so container's local time matches the user's
     args.extend(["-e", f"TZ={TIMEZONE}"])
 
+    # NATS connection for IPC
+    nats_url = NATS_URL.replace("localhost", CONTAINER_HOST_GATEWAY)
+    args.extend(["-e", f"NATS_URL={nats_url}"])
+    args.extend(["-e", f"JOB_ID={job_id}"])
+
     # Route API traffic through the credential proxy (containers never see real secrets)
     args.extend(
         [
@@ -295,9 +256,6 @@ def build_container_args(
     )
 
     # Mirror the host's auth method with a placeholder value.
-    # API key mode: SDK sends x-api-key, proxy replaces with real key.
-    # OAuth mode:   SDK exchanges placeholder token for temp API key,
-    #               proxy injects real OAuth token on that exchange request.
     auth_mode = detect_auth_mode()
     if auth_mode == "api-key":
         args.extend(["-e", "ANTHROPIC_API_KEY=placeholder"])
@@ -308,8 +266,6 @@ def build_container_args(
     args.extend(host_gateway_args())
 
     # Run as host user so bind-mounted files are accessible.
-    # Skip when running as root (uid 0), as the container's node user (uid 1000),
-    # or when getuid is unavailable.
     host_uid: int | None = None
     host_gid: int | None = None
     if hasattr(os, "getuid"):
@@ -336,11 +292,14 @@ async def run_container_agent(
     inp: ContainerInput,
     on_process: Callable[[asyncio.subprocess.Process, str], None],
     on_output: Callable[[ContainerOutput], Awaitable[None]] | None = None,
+    transport: NatsTransport | None = None,
 ) -> ContainerOutput:
-    """Run the agent inside a container and return the parsed output.
+    """Run the agent inside a container with NATS-based IPC.
 
-    Streams stdout looking for OUTPUT_START_MARKER/OUTPUT_END_MARKER pairs.
-    Resets the timeout on each streamed output marker.
+    Channel 1: Writes initial input to KV before starting container.
+    Channel 2: Subscribes to JetStream for streaming results.
+    Channel 6: Writes snapshots to KV before starting container.
+    Stderr is still read for logging purposes.
     """
     start_time = time.monotonic()
     start_epoch_ms = int(time.time() * 1000)
@@ -348,15 +307,18 @@ async def run_container_agent(
     group_dir = resolve_group_folder_path(group.folder)
     group_dir.mkdir(parents=True, exist_ok=True)
 
+    job_id = f"{group.folder}-{uuid.uuid4().hex[:12]}"
+
     mounts = build_volume_mounts(group, inp.is_main)
     safe_name = re.sub(r"[^a-zA-Z0-9-]", "-", group.folder)
     container_name = f"nanoclaw-{safe_name}-{start_epoch_ms}"
-    container_args = build_container_args(mounts, container_name)
+    container_args = build_container_args(mounts, container_name, job_id)
 
     logger.debug(
         "Container mount configuration",
         group=group.name,
         container_name=container_name,
+        job_id=job_id,
         mounts=[f"{m.host_path} -> {m.container_path}{' (ro)' if m.readonly else ''}" for m in mounts],
         container_args=" ".join(container_args),
     )
@@ -365,6 +327,7 @@ async def run_container_agent(
         "Spawning container agent",
         group=group.name,
         container_name=container_name,
+        job_id=job_id,
         mount_count=len(mounts),
         is_main=inp.is_main,
     )
@@ -372,29 +335,36 @@ async def run_container_agent(
     logs_dir = group_dir / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
 
+    # Channel 1: Write initial input to KV before starting container
+    if transport is not None:
+        kv_init = await transport.js.key_value("agent-init")
+        init_data = json.dumps(
+            {
+                "prompt": inp.prompt,
+                "group_folder": inp.group_folder,
+                "chat_jid": inp.chat_jid,
+                "is_main": inp.is_main,
+                "session_id": inp.session_id,
+                "is_scheduled_task": inp.is_scheduled_task,
+                "assistant_name": inp.assistant_name,
+            }
+        ).encode()
+        await kv_init.put(job_id, init_data)
+
     proc = await asyncio.create_subprocess_exec(
         CONTAINER_RUNTIME_BIN,
         *container_args,
-        stdin=asyncio.subprocess.PIPE,
+        stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
 
     on_process(proc, container_name)
 
-    # Write input to container stdin
-    input_payload = json.dumps(_serialize_container_input(inp)).encode("utf-8")
-    assert proc.stdin is not None
-    proc.stdin.write(input_payload)
-    proc.stdin.close()
-
-    stdout_buf = ""
     stderr_buf = ""
-    stdout_truncated = False
     stderr_truncated = False
 
     # Streaming output state
-    parse_buffer = ""
     new_session_id: str | None = None
     had_streaming_output = False
     timed_out = False
@@ -402,8 +372,6 @@ async def run_container_agent(
     config_timeout = (
         group.container_config.timeout if group.container_config else CONTAINER_TIMEOUT
     ) or CONTAINER_TIMEOUT
-    # Grace period: hard timeout must be at least IDLE_TIMEOUT + 30s so the
-    # graceful _close sentinel has time to trigger before the hard kill fires.
     timeout_ms = max(config_timeout, IDLE_TIMEOUT + 30_000)
     timeout_s = timeout_ms / 1000.0
 
@@ -425,7 +393,6 @@ async def run_container_agent(
                     group=group.name,
                     container_name=container_name,
                 )
-                # Attempt graceful stop
                 try:
                     stop_proc = await asyncio.create_subprocess_exec(
                         *stop_container(container_name).split(),
@@ -447,61 +414,33 @@ async def run_container_agent(
 
     timeout_task = asyncio.create_task(_timeout_watcher())
 
-    async def _read_stdout() -> None:
-        nonlocal stdout_buf, stdout_truncated, parse_buffer
+    # Channel 2: Subscribe to JetStream for streaming results
+    results_sub = None
+    if transport is not None and on_output is not None:
+        results_sub = await transport.js.subscribe(f"agent.{job_id}.results")
+
+    async def _read_results() -> None:
         nonlocal new_session_id, had_streaming_output
-        assert proc.stdout is not None
-        while True:
-            chunk_bytes = await proc.stdout.read(8192)
-            if not chunk_bytes:
-                break
-            chunk = chunk_bytes.decode("utf-8", errors="replace")
-
-            # Accumulate for logging
-            if not stdout_truncated:
-                remaining = CONTAINER_MAX_OUTPUT_SIZE - len(stdout_buf)
-                if len(chunk) > remaining:
-                    stdout_buf += chunk[:remaining]
-                    stdout_truncated = True
-                    logger.warning(
-                        "Container stdout truncated due to size limit",
-                        group=group.name,
-                        size=len(stdout_buf),
-                    )
-                else:
-                    stdout_buf += chunk
-
-            # Stream-parse for output markers
-            if on_output is not None:
-                parse_buffer += chunk
-                while True:
-                    start_idx = parse_buffer.find(OUTPUT_START_MARKER)
-                    if start_idx == -1:
-                        break
-                    end_idx = parse_buffer.find(OUTPUT_END_MARKER, start_idx)
-                    if end_idx == -1:
-                        break  # Incomplete pair, wait for more data
-
-                    json_str = parse_buffer[start_idx + len(OUTPUT_START_MARKER) : end_idx].strip()
-                    parse_buffer = parse_buffer[end_idx + len(OUTPUT_END_MARKER) :]
-
-                    try:
-                        raw = json.loads(json_str)
-                        parsed = _parse_container_output(raw)
-                        if parsed.new_session_id:
-                            new_session_id = parsed.new_session_id
-                        had_streaming_output = True
-                        # Activity detected - reset the hard timeout
-                        activity_event.set()
-                        # Call on_output for all markers (including null results)
-                        # so idle timers start even for "silent" query completions.
-                        await on_output(parsed)
-                    except (json.JSONDecodeError, KeyError, TypeError) as err:
-                        logger.warning(
-                            "Failed to parse streamed output chunk",
-                            group=group.name,
-                            error=str(err),
-                        )
+        if results_sub is None:
+            return
+        async for msg in results_sub.messages:
+            try:
+                raw = json.loads(msg.data)
+                parsed = _parse_container_output(raw)
+                if parsed.new_session_id:
+                    new_session_id = parsed.new_session_id
+                had_streaming_output = True
+                activity_event.set()
+                if on_output is not None:
+                    await on_output(parsed)
+                await msg.ack()
+            except (json.JSONDecodeError, KeyError, TypeError) as err:
+                logger.warning(
+                    "Failed to parse streamed output",
+                    group=group.name,
+                    error=str(err),
+                )
+                await msg.ack()
 
     async def _read_stderr() -> None:
         nonlocal stderr_buf, stderr_truncated
@@ -515,8 +454,6 @@ async def run_container_agent(
             for line in lines:
                 if line:
                     logger.debug(line, container=group.folder)
-            # Don't reset timeout on stderr - SDK writes debug logs continuously.
-            # Timeout only resets on actual output (OUTPUT_MARKER in stdout).
             if stderr_truncated:
                 continue
             remaining = CONTAINER_MAX_OUTPUT_SIZE - len(stderr_buf)
@@ -531,11 +468,21 @@ async def run_container_agent(
             else:
                 stderr_buf += chunk
 
-    # Run stdout/stderr readers concurrently
-    await asyncio.gather(_read_stdout(), _read_stderr())
+    # Run readers concurrently
+    tasks: list[asyncio.Task[None]] = [asyncio.create_task(_read_stderr())]
+    if results_sub is not None:
+        tasks.append(asyncio.create_task(_read_results()))
 
     # Wait for process to exit
     code = await proc.wait()
+
+    # Cancel the results subscription and readers
+    if results_sub is not None:
+        await results_sub.unsubscribe()
+    for t in tasks:
+        t.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await t
 
     # Cancel the timeout watcher
     timeout_task.cancel()
@@ -554,6 +501,7 @@ async def run_container_agent(
                     f"Timestamp: {datetime.now(UTC).isoformat()}",
                     f"Group: {group.name}",
                     f"Container: {container_name}",
+                    f"Job ID: {job_id}",
                     f"Duration: {duration_ms}ms",
                     f"Exit Code: {code}",
                     f"Had Streaming Output: {had_streaming_output}",
@@ -562,9 +510,6 @@ async def run_container_agent(
             encoding="utf-8",
         )
 
-        # Timeout after output = idle cleanup, not failure.
-        # The agent already sent its response; this is just the
-        # container being reaped after the idle period expired.
         if had_streaming_output:
             logger.info(
                 "Container timed out after output (idle cleanup)",
@@ -601,9 +546,9 @@ async def run_container_agent(
         f"Timestamp: {datetime.now(UTC).isoformat()}",
         f"Group: {group.name}",
         f"IsMain: {inp.is_main}",
+        f"Job ID: {job_id}",
         f"Duration: {duration_ms}ms",
         f"Exit Code: {code}",
-        f"Stdout Truncated: {stdout_truncated}",
         f"Stderr Truncated: {stderr_truncated}",
         "",
     ]
@@ -611,14 +556,13 @@ async def run_container_agent(
     is_error = code != 0
 
     if is_verbose or is_error:
-        # On error, log input metadata only - not the full prompt.
-        # Full input is only included at verbose level to avoid
-        # persisting user conversation content on every non-zero exit.
         if is_verbose:
             log_lines.extend(
                 [
-                    "=== Input ===",
-                    json.dumps(_serialize_container_input(inp), indent=2),
+                    "=== Input Summary ===",
+                    f"Prompt length: {len(inp.prompt)} chars",
+                    f"Session ID: {inp.session_id or 'new'}",
+                    f"Job ID: {job_id}",
                     "",
                 ]
             )
@@ -641,9 +585,6 @@ async def run_container_agent(
                 "",
                 f"=== Stderr{' (TRUNCATED)' if stderr_truncated else ''} ===",
                 stderr_buf,
-                "",
-                f"=== Stdout{' (TRUNCATED)' if stdout_truncated else ''} ===",
-                stdout_buf,
             ]
         )
     else:
@@ -669,7 +610,6 @@ async def run_container_agent(
             code=code,
             duration=duration_ms,
             stderr=stderr_buf,
-            stdout=stdout_buf,
             log_file=str(log_file),
         )
         return ContainerOutput(
@@ -679,94 +619,47 @@ async def run_container_agent(
         )
 
     # Streaming mode: return completion marker
-    if on_output is not None:
-        logger.info(
-            "Container completed (streaming mode)",
-            group=group.name,
-            duration=duration_ms,
-            new_session_id=new_session_id,
-        )
-        return ContainerOutput(
-            status="success",
-            result=None,
-            new_session_id=new_session_id,
-        )
-
-    # Legacy mode: parse the last output marker pair from accumulated stdout
-    try:
-        # Extract JSON between sentinel markers for robust parsing
-        start_idx = stdout_buf.find(OUTPUT_START_MARKER)
-        end_idx = stdout_buf.find(OUTPUT_END_MARKER)
-
-        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-            json_line = stdout_buf[start_idx + len(OUTPUT_START_MARKER) : end_idx].strip()
-        else:
-            # Fallback: last non-empty line (backwards compatibility)
-            lines = stdout_buf.strip().split("\n")
-            json_line = lines[-1]
-
-        raw = json.loads(json_line)
-        output = _parse_container_output(raw)
-
-        logger.info(
-            "Container completed",
-            group=group.name,
-            duration=duration_ms,
-            status=output.status,
-            has_result=output.result is not None,
-        )
-        return output
-
-    except (json.JSONDecodeError, KeyError, TypeError, IndexError) as err:
-        logger.error(
-            "Failed to parse container output",
-            group=group.name,
-            stdout=stdout_buf,
-            stderr=stderr_buf,
-            error=str(err),
-        )
-        return ContainerOutput(
-            status="error",
-            result=None,
-            error=f"Failed to parse container output: {err}",
-        )
+    logger.info(
+        "Container completed",
+        group=group.name,
+        duration=duration_ms,
+        new_session_id=new_session_id,
+    )
+    return ContainerOutput(
+        status="success",
+        result=None,
+        new_session_id=new_session_id,
+    )
 
 
-def write_tasks_snapshot(
+async def write_tasks_snapshot(
+    transport: NatsTransport,
     group_folder: str,
     is_main: bool,
     tasks: list[dict[str, object]],
 ) -> None:
-    """Write filtered tasks to the group's IPC directory.
+    """Write filtered tasks to NATS KV for the agent to read.
 
     Main sees all tasks, others only see their own.
     """
-    group_ipc_dir = resolve_group_ipc_path(group_folder)
-    group_ipc_dir.mkdir(parents=True, exist_ok=True)
-
-    # Main sees all tasks, others only see their own
     filtered_tasks: list[dict[str, object]]
     filtered_tasks = tasks if is_main else [t for t in tasks if t.get("groupFolder") == group_folder]
 
-    tasks_file = group_ipc_dir / "current_tasks.json"
-    tasks_file.write_text(json.dumps(filtered_tasks, indent=2), encoding="utf-8")
+    kv = await transport.js.key_value("snapshots")
+    await kv.put(f"{group_folder}.tasks", json.dumps(filtered_tasks).encode())
 
 
-def write_groups_snapshot(
+async def write_groups_snapshot(
+    transport: NatsTransport,
     group_folder: str,
     is_main: bool,
     groups: list[AvailableGroup],
     _registered_jids: set[str],
 ) -> None:
-    """Write available groups snapshot for the container to read.
+    """Write available groups snapshot to NATS KV for the agent to read.
 
     Only main group can see all available groups (for activation).
-    Non-main groups only see their own registration status.
     """
-    group_ipc_dir = resolve_group_ipc_path(group_folder)
-    group_ipc_dir.mkdir(parents=True, exist_ok=True)
-
-    # Main sees all groups; others see nothing (they can't activate groups)
     visible_groups: list[dict[str, object]]
     if is_main:
         visible_groups = [
@@ -781,14 +674,13 @@ def write_groups_snapshot(
     else:
         visible_groups = []
 
-    groups_file = group_ipc_dir / "available_groups.json"
-    groups_file.write_text(
+    kv = await transport.js.key_value("snapshots")
+    await kv.put(
+        f"{group_folder}.groups",
         json.dumps(
             {
                 "groups": visible_groups,
                 "lastSync": datetime.now(UTC).isoformat(),
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
+            }
+        ).encode(),
     )

--- a/py/src/nanoclaw/container/runner.py
+++ b/py/src/nanoclaw/container/runner.py
@@ -290,7 +290,7 @@ def build_container_args(
 async def run_container_agent(
     group: RegisteredGroup,
     inp: ContainerInput,
-    on_process: Callable[[asyncio.subprocess.Process, str], None],
+    on_process: Callable[[asyncio.subprocess.Process, str, str], None],
     on_output: Callable[[ContainerOutput], Awaitable[None]] | None = None,
     transport: NatsTransport | None = None,
 ) -> ContainerOutput:
@@ -359,7 +359,7 @@ async def run_container_agent(
         stderr=asyncio.subprocess.PIPE,
     )
 
-    on_process(proc, container_name)
+    on_process(proc, container_name, job_id)
 
     stderr_buf = ""
     stderr_truncated = False

--- a/py/src/nanoclaw/container/scheduler.py
+++ b/py/src/nanoclaw/container/scheduler.py
@@ -12,11 +12,14 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from nanoclaw.core.config import DATA_DIR, MAX_CONCURRENT_CONTAINERS
 from nanoclaw.core.logger import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+
+    from nanoclaw.ipc.nats_transport import NatsTransport
+
+from nanoclaw.core.config import MAX_CONCURRENT_CONTAINERS
 
 logger = get_logger()
 
@@ -42,19 +45,21 @@ class _GroupState:
     process: object | None = None  # asyncio.subprocess.Process
     container_name: str | None = None
     group_folder: str | None = None
+    job_id: str | None = None
     retry_count: int = 0
 
 
 class GroupQueue:
     """Manages per-group container concurrency and task/message queuing."""
 
-    def __init__(self) -> None:
+    def __init__(self, transport: NatsTransport | None = None) -> None:
         self._groups: dict[str, _GroupState] = {}
         self._active_count: int = 0
         self._waiting_groups: list[str] = []
         self._process_messages_fn: Callable[[str], Awaitable[bool]] | None = None
         self._shutting_down: bool = False
         self._background_tasks: set[asyncio.Task[None]] = set()
+        self._transport = transport
 
     def _spawn(self, coro: Awaitable[None]) -> None:
         """Launch a background task and track it to prevent GC."""
@@ -142,6 +147,7 @@ class GroupQueue:
         proc: object,
         container_name: str,
         group_folder: str | None = None,
+        job_id: str | None = None,
     ) -> None:
         """Track an active container process for a group."""
         state = self._get_group(group_jid)
@@ -149,6 +155,8 @@ class GroupQueue:
         state.container_name = container_name
         if group_folder:
             state.group_folder = group_folder
+        if job_id:
+            state.job_id = job_id
 
     def notify_idle(self, group_jid: str) -> None:
         """Mark container as idle-waiting. Preempt if tasks pending."""
@@ -158,38 +166,57 @@ class GroupQueue:
             self.close_stdin(group_jid)
 
     def send_message(self, group_jid: str, text: str) -> bool:
-        """Send a follow-up message to the active container via IPC file."""
+        """Send a follow-up message to the active container via NATS JetStream."""
         state = self._get_group(group_jid)
-        if not state.active or not state.group_folder or state.is_task_container:
+        if not state.active or not state.job_id or state.is_task_container:
             return False
         state.idle_waiting = False
 
-        input_dir = DATA_DIR / "ipc" / state.group_folder / "input"
-        try:
-            input_dir.mkdir(parents=True, exist_ok=True)
-            import time
+        if self._transport is None:
+            return False
 
-            filename = f"{int(time.time() * 1000)}-{id(text) % 10000:04d}.json"
-            filepath = input_dir / filename
-            temp_path = filepath.with_suffix(".json.tmp")
-            temp_path.write_text(json.dumps({"type": "message", "text": text}))
-            temp_path.rename(filepath)
+        try:
+
+            async def _send() -> None:
+                assert self._transport is not None
+                assert state.job_id is not None
+                await self._transport.js.publish(
+                    f"agent.{state.job_id}.input",
+                    json.dumps({"type": "message", "text": text}).encode(),
+                )
+
+            bg = asyncio.ensure_future(_send())
+            self._background_tasks.add(bg)
+            bg.add_done_callback(self._background_tasks.discard)
             return True
-        except OSError:
+        except (OSError, RuntimeError):
+            logger.exception("Failed to send follow-up message via NATS", group_jid=group_jid)
             return False
 
     def close_stdin(self, group_jid: str) -> None:
-        """Signal the active container to wind down."""
+        """Signal the active container to wind down via NATS request-reply."""
         state = self._get_group(group_jid)
-        if not state.active or not state.group_folder:
+        if not state.active or not state.job_id:
             return
 
-        input_dir = DATA_DIR / "ipc" / state.group_folder / "input"
-        try:
-            input_dir.mkdir(parents=True, exist_ok=True)
-            (input_dir / "_close").write_text("")
-        except OSError:
-            pass
+        if self._transport is None:
+            return
+
+        async def _send_close() -> None:
+            assert self._transport is not None
+            assert state.job_id is not None
+            try:
+                await self._transport.nc.request(
+                    f"agent.{state.job_id}.close",
+                    b"close",
+                    timeout=5.0,
+                )
+            except (OSError, TimeoutError):
+                logger.debug("Close signal not acknowledged (agent may have exited)", group_jid=group_jid)
+
+        task = asyncio.ensure_future(_send_close())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     async def _run_for_group(self, group_jid: str, reason: str) -> None:
         state = self._get_group(group_jid)
@@ -221,6 +248,7 @@ class GroupQueue:
             state.process = None
             state.container_name = None
             state.group_folder = None
+            state.job_id = None
             self._active_count -= 1
             self._drain_group(group_jid)
 
@@ -250,6 +278,7 @@ class GroupQueue:
             state.process = None
             state.container_name = None
             state.group_folder = None
+            state.job_id = None
             self._active_count -= 1
             self._drain_group(group_jid)
 
@@ -311,7 +340,7 @@ class GroupQueue:
                 self._spawn(self._run_for_group(next_jid, "drain"))
 
     async def shutdown(self, _grace_period_ms: int = 0) -> None:
-        """Graceful shutdown — detach containers, don't kill them."""
+        """Graceful shutdown -- detach containers, don't kill them."""
         self._shutting_down = True
 
         active_containers: list[str] = []

--- a/py/src/nanoclaw/core/config.py
+++ b/py/src/nanoclaw/core/config.py
@@ -17,7 +17,6 @@ ASSISTANT_HAS_OWN_NUMBER: bool = (
 
 POLL_INTERVAL: float = 2.0  # seconds
 SCHEDULER_POLL_INTERVAL: float = 60.0  # seconds
-IPC_POLL_INTERVAL: float = 1.0  # seconds
 
 PROJECT_ROOT: Path = Path.cwd()
 HOME_DIR: Path = Path.home()
@@ -27,6 +26,8 @@ SENDER_ALLOWLIST_PATH: Path = HOME_DIR / ".config" / "nanoclaw" / "sender-allowl
 STORE_DIR: Path = PROJECT_ROOT / "store"
 GROUPS_DIR: Path = PROJECT_ROOT / "groups"
 DATA_DIR: Path = PROJECT_ROOT / "data"
+
+NATS_URL: str = os.environ.get("NATS_URL", "nats://localhost:4222")
 
 CONTAINER_IMAGE: str = os.environ.get("CONTAINER_IMAGE", "nanoclaw-agent:latest")
 CONTAINER_TIMEOUT: int = int(os.environ.get("CONTAINER_TIMEOUT", "1800000"))

--- a/py/src/nanoclaw/ipc/__init__.py
+++ b/py/src/nanoclaw/ipc/__init__.py
@@ -1,5 +1,7 @@
-"""IPC layer — file-based transport."""
+"""IPC layer -- NATS-based messaging between Orchestrator and Agent."""
 
-from nanoclaw.ipc.file_transport import start_ipc_watcher
+from nanoclaw.ipc.nats_transport import NatsTransport
+from nanoclaw.ipc.protocol import AgentInitData, IpcEnvelope
+from nanoclaw.ipc.task_handler import IpcDeps, process_task_ipc
 
-__all__ = ["start_ipc_watcher"]
+__all__ = ["AgentInitData", "IpcDeps", "IpcEnvelope", "NatsTransport", "process_task_ipc"]

--- a/py/src/nanoclaw/ipc/__init__.py
+++ b/py/src/nanoclaw/ipc/__init__.py
@@ -1,7 +1,7 @@
 """IPC layer -- NATS-based messaging between Orchestrator and Agent."""
 
 from nanoclaw.ipc.nats_transport import NatsTransport
-from nanoclaw.ipc.protocol import AgentInitData, IpcEnvelope
+from nanoclaw.ipc.protocol import AgentInitData
 from nanoclaw.ipc.task_handler import IpcDeps, process_task_ipc
 
-__all__ = ["AgentInitData", "IpcDeps", "IpcEnvelope", "NatsTransport", "process_task_ipc"]
+__all__ = ["AgentInitData", "IpcDeps", "NatsTransport", "process_task_ipc"]

--- a/py/src/nanoclaw/ipc/nats_transport.py
+++ b/py/src/nanoclaw/ipc/nats_transport.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import nats
-from nats.js.api import KeyValueConfig, RetentionPolicy, StreamConfig
+from nats.js.api import KeyValueConfig, StreamConfig
 
 from nanoclaw.core.logger import get_logger
 
@@ -59,12 +59,14 @@ class NatsTransport:
             ) from exc
         self._js = self._nc.jetstream()
 
-        # Create JetStream stream for agent communication
+        # Create JetStream stream for agent communication.
+        # Uses LIMITS retention (default) — WorkQueue doesn't allow multiple
+        # consumers with overlapping subject filters, which we need since both
+        # orchestrator and agent subscribe to different subjects in this stream.
         await self._js.add_stream(
             StreamConfig(
                 name="agent-ipc",
                 subjects=["agent.*.results", "agent.*.input", "agent.*.messages", "agent.*.tasks"],
-                retention=RetentionPolicy.WORK_QUEUE,
                 max_age=_STREAM_MAX_AGE_S,
             )
         )

--- a/py/src/nanoclaw/ipc/nats_transport.py
+++ b/py/src/nanoclaw/ipc/nats_transport.py
@@ -42,6 +42,7 @@ class NatsTransport:
 
         Raises ConnectionError if NATS is unreachable.
         """
+
         async def _quiet_error(exc: Exception) -> None:
             logger.debug("NATS connection attempt failed", error=str(exc))
 

--- a/py/src/nanoclaw/ipc/nats_transport.py
+++ b/py/src/nanoclaw/ipc/nats_transport.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-# Stream TTL: 1 hour in nanoseconds
-_STREAM_MAX_AGE_NS = 3_600_000_000_000
+# Stream max age: 1 hour in seconds (nats-py converts to nanoseconds internally)
+_STREAM_MAX_AGE_S = 3600.0
 
 # KV TTL: 1 hour in seconds
-_KV_TTL_SECONDS = 3600
+_KV_TTL_SECONDS = 3600.0
 
 
 class NatsTransport:
@@ -46,9 +46,9 @@ class NatsTransport:
         await self._js.add_stream(
             StreamConfig(
                 name="agent-ipc",
-                subjects=["agent.>"],
+                subjects=["agent.*.results", "agent.*.input", "agent.*.messages", "agent.*.tasks"],
                 retention=RetentionPolicy.WORK_QUEUE,
-                max_age=_STREAM_MAX_AGE_NS,
+                max_age=_STREAM_MAX_AGE_S,
             )
         )
 

--- a/py/src/nanoclaw/ipc/nats_transport.py
+++ b/py/src/nanoclaw/ipc/nats_transport.py
@@ -1,0 +1,79 @@
+"""NATS transport for Orchestrator-side IPC.
+
+Manages JetStream streams and KV buckets used for all 6 IPC channels
+between the Orchestrator and container Agents.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import nats
+from nats.js.api import KeyValueConfig, RetentionPolicy, StreamConfig
+
+from nanoclaw.core.logger import get_logger
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client
+    from nats.js.client import JetStreamContext
+
+logger = get_logger()
+
+# Stream TTL: 1 hour in nanoseconds
+_STREAM_MAX_AGE_NS = 3_600_000_000_000
+
+# KV TTL: 1 hour in seconds
+_KV_TTL_SECONDS = 3600
+
+
+class NatsTransport:
+    """NATS transport for Orchestrator-side IPC.
+
+    Provides JetStream and KV access after connect().
+    """
+
+    def __init__(self, url: str = "nats://localhost:4222") -> None:
+        self._url = url
+        self._nc: Client | None = None
+        self._js: JetStreamContext | None = None
+
+    async def connect(self) -> None:
+        """Connect to NATS and create JetStream stream + KV buckets."""
+        self._nc = await nats.connect(self._url)
+        self._js = self._nc.jetstream()
+
+        # Create JetStream stream for agent communication
+        await self._js.add_stream(
+            StreamConfig(
+                name="agent-ipc",
+                subjects=["agent.>"],
+                retention=RetentionPolicy.WORK_QUEUE,
+                max_age=_STREAM_MAX_AGE_NS,
+            )
+        )
+
+        # Create KV buckets
+        await self._js.create_key_value(config=KeyValueConfig(bucket="agent-init", ttl=_KV_TTL_SECONDS))
+        await self._js.create_key_value(config=KeyValueConfig(bucket="snapshots", ttl=_KV_TTL_SECONDS))
+
+        logger.info("NATS connected", url=self._url)
+
+    @property
+    def nc(self) -> Client:
+        """Return the raw NATS client. Raises if not connected."""
+        assert self._nc is not None, "NatsTransport not connected"
+        return self._nc
+
+    @property
+    def js(self) -> JetStreamContext:
+        """Return the JetStream context. Raises if not connected."""
+        assert self._js is not None, "NatsTransport not connected"
+        return self._js
+
+    async def close(self) -> None:
+        """Close the NATS connection."""
+        if self._nc:
+            await self._nc.close()
+            self._nc = None
+            self._js = None
+            logger.info("NATS connection closed")

--- a/py/src/nanoclaw/ipc/nats_transport.py
+++ b/py/src/nanoclaw/ipc/nats_transport.py
@@ -38,8 +38,25 @@ class NatsTransport:
         self._js: JetStreamContext | None = None
 
     async def connect(self) -> None:
-        """Connect to NATS and create JetStream stream + KV buckets."""
-        self._nc = await nats.connect(self._url)
+        """Connect to NATS and create JetStream stream + KV buckets.
+
+        Raises ConnectionError if NATS is unreachable.
+        """
+        async def _quiet_error(exc: Exception) -> None:
+            logger.debug("NATS connection attempt failed", error=str(exc))
+
+        try:
+            self._nc = await nats.connect(
+                self._url,
+                max_reconnect_attempts=3,
+                reconnect_time_wait=1,
+                error_cb=_quiet_error,
+            )
+        except Exception as exc:
+            raise ConnectionError(
+                f"Cannot connect to NATS at {self._url}. "
+                f"Start NATS with: docker compose -f docker-compose.dev.yml up -d"
+            ) from exc
         self._js = self._nc.jetstream()
 
         # Create JetStream stream for agent communication

--- a/py/src/nanoclaw/ipc/protocol.py
+++ b/py/src/nanoclaw/ipc/protocol.py
@@ -7,31 +7,11 @@ from dataclasses import asdict, dataclass
 
 
 @dataclass(frozen=True)
-class IpcEnvelope:
-    """Wrapper for all IPC messages sent over NATS JetStream."""
-
-    type: str
-    group_folder: str
-    timestamp: str
-    payload: dict[str, object]
-
-    def serialize(self) -> bytes:
-        return json.dumps(asdict(self)).encode()
-
-    @classmethod
-    def deserialize(cls, data: bytes) -> IpcEnvelope:
-        raw = json.loads(data)
-        return cls(
-            type=raw["type"],
-            group_folder=raw["group_folder"],
-            timestamp=raw["timestamp"],
-            payload=raw["payload"],
-        )
-
-
-@dataclass(frozen=True)
 class AgentInitData:
-    """Channel 1: initial input written to KV before container starts."""
+    """Channel 1: initial input written to KV before container starts.
+
+    Shared between orchestrator (serialize) and agent runner (deserialize).
+    """
 
     prompt: str
     group_folder: str

--- a/py/src/nanoclaw/ipc/protocol.py
+++ b/py/src/nanoclaw/ipc/protocol.py
@@ -1,0 +1,58 @@
+"""IPC message types for NATS-based communication between Orchestrator and Agent."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class IpcEnvelope:
+    """Wrapper for all IPC messages sent over NATS JetStream."""
+
+    type: str
+    group_folder: str
+    timestamp: str
+    payload: dict[str, object]
+
+    def serialize(self) -> bytes:
+        return json.dumps(asdict(self)).encode()
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> IpcEnvelope:
+        raw = json.loads(data)
+        return cls(
+            type=raw["type"],
+            group_folder=raw["group_folder"],
+            timestamp=raw["timestamp"],
+            payload=raw["payload"],
+        )
+
+
+@dataclass(frozen=True)
+class AgentInitData:
+    """Channel 1: initial input written to KV before container starts."""
+
+    prompt: str
+    group_folder: str
+    chat_jid: str
+    is_main: bool
+    session_id: str | None = None
+    is_scheduled_task: bool = False
+    assistant_name: str | None = None
+
+    def serialize(self) -> bytes:
+        return json.dumps(asdict(self)).encode()
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> AgentInitData:
+        raw = json.loads(data)
+        return cls(
+            prompt=raw["prompt"],
+            group_folder=raw["group_folder"],
+            chat_jid=raw["chat_jid"],
+            is_main=raw["is_main"],
+            session_id=raw.get("session_id"),
+            is_scheduled_task=raw.get("is_scheduled_task", False),
+            assistant_name=raw.get("assistant_name"),
+        )

--- a/py/src/nanoclaw/ipc/task_handler.py
+++ b/py/src/nanoclaw/ipc/task_handler.py
@@ -1,14 +1,12 @@
-"""IPC watcher and task processing.
+"""IPC task processing logic.
 
-Polls per-group IPC directories for message and task files.
-Each group's identity is determined by its directory name, providing
-namespace isolation and authorization enforcement.
+Handles task and message IPC payloads from agents, regardless of transport.
+Authorization: main group can manage any task; non-main groups are restricted
+to their own group folder.
 """
 
 from __future__ import annotations
 
-import asyncio
-import json
 import random
 import string
 import time
@@ -17,7 +15,6 @@ from typing import TYPE_CHECKING, Protocol
 
 from croniter import croniter
 
-from nanoclaw.core.config import DATA_DIR, IPC_POLL_INTERVAL
 from nanoclaw.core.group_folder import is_valid_group_folder
 from nanoclaw.core.logger import get_logger
 from nanoclaw.core.types import RegisteredGroup, ScheduledTask
@@ -25,7 +22,6 @@ from nanoclaw.db.sqlite import create_task, delete_task, get_task_by_id, update_
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-    from pathlib import Path
 
     from nanoclaw.container.runner import AvailableGroup
 
@@ -33,7 +29,7 @@ logger = get_logger()
 
 
 class IpcDeps(Protocol):
-    """Dependencies injected into the IPC watcher."""
+    """Dependencies injected into IPC handlers."""
 
     def send_message(self, jid: str, text: str) -> Awaitable[None]: ...
     def registered_groups(self) -> dict[str, RegisteredGroup]: ...
@@ -48,101 +44,6 @@ class IpcDeps(Protocol):
         registered_jids: set[str],
     ) -> None: ...
     def on_tasks_changed(self) -> None: ...
-
-
-_ipc_watcher_running: bool = False
-
-
-def start_ipc_watcher(deps: IpcDeps) -> asyncio.Task[None]:
-    """Launch an asyncio task that polls per-group IPC directories."""
-    global _ipc_watcher_running
-    if _ipc_watcher_running:
-        logger.debug("IPC watcher already running, skipping duplicate start")
-        # Return a completed task as a no-op
-        loop = asyncio.get_running_loop()
-        fut: asyncio.Future[None] = loop.create_future()
-        fut.set_result(None)
-        return asyncio.ensure_future(fut)
-    _ipc_watcher_running = True
-
-    ipc_base_dir = DATA_DIR / "ipc"
-    ipc_base_dir.mkdir(parents=True, exist_ok=True)
-
-    async def _poll_loop() -> None:
-        while True:
-            await _process_ipc_files(ipc_base_dir, deps)
-            await asyncio.sleep(IPC_POLL_INTERVAL)
-
-    task = asyncio.create_task(_poll_loop())
-    logger.info("IPC watcher started (per-group namespaces)")
-    return task
-
-
-async def _process_ipc_files(ipc_base_dir: Path, deps: IpcDeps) -> None:
-    """Scan all group IPC directories and process pending files."""
-    try:
-        group_folders = [f.name for f in ipc_base_dir.iterdir() if f.is_dir() and f.name != "errors"]
-    except OSError:
-        logger.exception("Error reading IPC base directory")
-        return
-
-    registered_groups = deps.registered_groups()
-
-    # Build folder -> isMain lookup from registered groups
-    folder_is_main: dict[str, bool] = {}
-    for group in registered_groups.values():
-        if group.is_main:
-            folder_is_main[group.folder] = True
-
-    for source_group in group_folders:
-        is_main = folder_is_main.get(source_group, False)
-        messages_dir = ipc_base_dir / source_group / "messages"
-        tasks_dir = ipc_base_dir / source_group / "tasks"
-
-        # Process messages from this group's IPC directory
-        try:
-            if messages_dir.exists():
-                message_files = sorted(f for f in messages_dir.iterdir() if f.suffix == ".json")
-                for file_path in message_files:
-                    try:
-                        data = json.loads(file_path.read_text(encoding="utf-8"))
-                        if data.get("type") == "message" and data.get("chatJid") and data.get("text"):
-                            # Authorization: verify this group can send to this chatJid
-                            target_group = registered_groups.get(data["chatJid"])
-                            if is_main or (target_group is not None and target_group.folder == source_group):
-                                await deps.send_message(data["chatJid"], data["text"])
-                                logger.info("IPC message sent", chat_jid=data["chatJid"], source_group=source_group)
-                            else:
-                                logger.warning(
-                                    "Unauthorized IPC message attempt blocked",
-                                    chat_jid=data["chatJid"],
-                                    source_group=source_group,
-                                )
-                        file_path.unlink()
-                    except Exception:
-                        logger.exception("Error processing IPC message", file=file_path.name, source_group=source_group)
-                        error_dir = ipc_base_dir / "errors"
-                        error_dir.mkdir(parents=True, exist_ok=True)
-                        file_path.rename(error_dir / f"{source_group}-{file_path.name}")
-        except OSError:
-            logger.exception("Error reading IPC messages directory", source_group=source_group)
-
-        # Process tasks from this group's IPC directory
-        try:
-            if tasks_dir.exists():
-                task_files = sorted(f for f in tasks_dir.iterdir() if f.suffix == ".json")
-                for file_path in task_files:
-                    try:
-                        data = json.loads(file_path.read_text(encoding="utf-8"))
-                        await process_task_ipc(data, source_group, is_main, deps)
-                        file_path.unlink()
-                    except Exception:
-                        logger.exception("Error processing IPC task", file=file_path.name, source_group=source_group)
-                        error_dir = ipc_base_dir / "errors"
-                        error_dir.mkdir(parents=True, exist_ok=True)
-                        file_path.rename(error_dir / f"{source_group}-{file_path.name}")
-        except OSError:
-            logger.exception("Error reading IPC tasks directory", source_group=source_group)
 
 
 async def process_task_ipc(
@@ -385,9 +286,3 @@ async def process_task_ipc(
 
     else:
         logger.warning("Unknown IPC task type", type=task_type)
-
-
-def _reset_ipc_watcher_for_tests() -> None:
-    """Reset module state for tests."""
-    global _ipc_watcher_running
-    _ipc_watcher_running = False

--- a/py/src/nanoclaw/main.py
+++ b/py/src/nanoclaw/main.py
@@ -605,7 +605,15 @@ async def main() -> None:
 
     # Connect to NATS for IPC
     _transport = NatsTransport(NATS_URL)
-    await _transport.connect()
+    try:
+        await _transport.connect()
+    except ConnectionError:
+        logger.critical(
+            "Failed to connect to NATS — is it running?",
+            url=NATS_URL,
+            hint="docker compose -f docker-compose.dev.yml up -d",
+        )
+        sys.exit(1)
 
     # Create queue with transport
     _queue = GroupQueue(transport=_transport)

--- a/py/src/nanoclaw/main.py
+++ b/py/src/nanoclaw/main.py
@@ -29,6 +29,7 @@ from nanoclaw.core.config import (
     ASSISTANT_NAME,
     CREDENTIAL_PROXY_PORT,
     IDLE_TIMEOUT,
+    NATS_URL,
     POLL_INTERVAL,
     TIMEZONE,
     TRIGGER_PATTERN,
@@ -50,7 +51,8 @@ from nanoclaw.db.sqlite import (
     store_chat_metadata,
     store_message,
 )
-from nanoclaw.ipc.file_transport import start_ipc_watcher
+from nanoclaw.ipc.nats_transport import NatsTransport
+from nanoclaw.ipc.task_handler import process_task_ipc
 from nanoclaw.orchestration.remote_control import (
     restore_remote_control,
     start_remote_control,
@@ -87,6 +89,8 @@ _message_loop_running: bool = False
 
 _channels: list[Channel] = []
 _queue: GroupQueue = GroupQueue()
+_transport: NatsTransport | None = None
+_bg_tasks: set[asyncio.Task[None]] = set()
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +167,85 @@ def _set_registered_groups(groups: dict[str, RegisteredGroup]) -> None:
     """Set registered groups (for testing)."""
     global _registered_groups
     _registered_groups = groups
+
+
+# ---------------------------------------------------------------------------
+# NATS subscription handlers (replace file-based IPC watcher)
+# ---------------------------------------------------------------------------
+
+
+async def _start_nats_ipc_subscriptions(transport: NatsTransport, deps: _IpcDepsImpl) -> list[asyncio.Task[None]]:
+    """Subscribe to NATS subjects for agent IPC messages and tasks.
+
+    Replaces the file-based IPC watcher (start_ipc_watcher).
+    Returns background tasks that should be cancelled on shutdown.
+    """
+    tasks: list[asyncio.Task[None]] = []
+
+    # Subscribe to agent messages (Channel 4: agent -> user)
+    messages_sub = await transport.js.subscribe("agent.*.messages")
+
+    async def _handle_messages() -> None:
+        async for msg in messages_sub.messages:
+            try:
+                data = json.loads(msg.data)
+                if data.get("type") == "message" and data.get("chatJid") and data.get("text"):
+                    chat_jid = data["chatJid"]
+                    source_group = data.get("groupFolder", "")
+
+                    # Authorization
+                    registered_groups = deps.registered_groups()
+                    # Determine if source is main
+                    folder_is_main: dict[str, bool] = {}
+                    for group in registered_groups.values():
+                        if group.is_main:
+                            folder_is_main[group.folder] = True
+                    is_main = folder_is_main.get(source_group, False)
+
+                    target_group = registered_groups.get(chat_jid)
+                    if is_main or (target_group is not None and target_group.folder == source_group):
+                        await deps.send_message(chat_jid, data["text"])
+                        logger.info("NATS IPC message sent", chat_jid=chat_jid, source_group=source_group)
+                    else:
+                        logger.warning(
+                            "Unauthorized IPC message attempt blocked",
+                            chat_jid=chat_jid,
+                            source_group=source_group,
+                        )
+                await msg.ack()
+            except Exception:
+                logger.exception("Error processing NATS IPC message")
+                await msg.ack()
+
+    tasks.append(asyncio.create_task(_handle_messages()))
+
+    # Subscribe to agent tasks (Channel 5: agent -> orch)
+    tasks_sub = await transport.js.subscribe("agent.*.tasks")
+
+    async def _handle_tasks() -> None:
+        async for msg in tasks_sub.messages:
+            try:
+                data = json.loads(msg.data)
+                source_group = data.get("groupFolder", data.get("createdBy", ""))
+
+                # Determine is_main
+                registered_groups = deps.registered_groups()
+                folder_is_main: dict[str, bool] = {}
+                for group in registered_groups.values():
+                    if group.is_main:
+                        folder_is_main[group.folder] = True
+                is_main = folder_is_main.get(source_group, False)
+
+                await process_task_ipc(data, source_group, is_main, deps)
+                await msg.ack()
+            except Exception:
+                logger.exception("Error processing NATS IPC task")
+                await msg.ack()
+
+    tasks.append(asyncio.create_task(_handle_tasks()))
+
+    logger.info("NATS IPC subscriptions started")
+    return tasks
 
 
 # ---------------------------------------------------------------------------
@@ -291,33 +374,35 @@ async def _run_agent(
     is_main = group.is_main
     session_id = _sessions.get(group.folder)
 
-    # Update tasks snapshot for container to read
-    tasks = get_all_tasks()
-    write_tasks_snapshot(
-        group.folder,
-        is_main,
-        [
-            {
-                "id": t.id,
-                "groupFolder": t.group_folder,
-                "prompt": t.prompt,
-                "schedule_type": t.schedule_type,
-                "schedule_value": t.schedule_value,
-                "status": t.status,
-                "next_run": t.next_run,
-            }
-            for t in tasks
-        ],
-    )
+    # Update snapshots in NATS KV for container to read (Channel 6)
+    if _transport is not None:
+        tasks = get_all_tasks()
+        await write_tasks_snapshot(
+            _transport,
+            group.folder,
+            is_main,
+            [
+                {
+                    "id": t.id,
+                    "groupFolder": t.group_folder,
+                    "prompt": t.prompt,
+                    "schedule_type": t.schedule_type,
+                    "schedule_value": t.schedule_value,
+                    "status": t.status,
+                    "next_run": t.next_run,
+                }
+                for t in tasks
+            ],
+        )
 
-    # Update available groups snapshot
-    available_groups = get_available_groups()
-    write_groups_snapshot(
-        group.folder,
-        is_main,
-        available_groups,
-        set(_registered_groups.keys()),
-    )
+        available_groups = get_available_groups()
+        await write_groups_snapshot(
+            _transport,
+            group.folder,
+            is_main,
+            available_groups,
+            set(_registered_groups.keys()),
+        )
 
     # Wrap on_output to track session ID from streamed results
     wrapped_on_output = None
@@ -345,6 +430,7 @@ async def _run_agent(
             ),
             lambda proc, container_name: _queue.register_process(chat_jid, proc, container_name, group.folder),
             wrapped_on_output,
+            transport=_transport,
         )
 
         if output.new_session_id:
@@ -509,11 +595,20 @@ async def _handle_remote_control(command: str, chat_jid: str, msg: NewMessage) -
 
 async def main() -> None:
     """Entry point for the NanoClaw orchestrator."""
+    global _transport, _queue
+
     _ensure_container_system_running()
     init_database()
     logger.info("Database initialized")
     _load_state()
     restore_remote_control()
+
+    # Connect to NATS for IPC
+    _transport = NatsTransport(NATS_URL)
+    await _transport.connect()
+
+    # Create queue with transport
+    _queue = GroupQueue(transport=_transport)
 
     # Start credential proxy (containers route API calls through this)
     proxy_runner = await start_credential_proxy(CREDENTIAL_PROXY_PORT, PROXY_BIND_HOST)
@@ -587,7 +682,11 @@ async def main() -> None:
 
     # Start subsystems
     start_scheduler_loop(_SchedulerDepsImpl())
-    start_ipc_watcher(_IpcDepsImpl())
+
+    # Start NATS IPC subscriptions (replaces file-based IPC watcher)
+    ipc_deps = _IpcDepsImpl()
+    ipc_tasks = await _start_nats_ipc_subscriptions(_transport, ipc_deps)
+
     _queue.set_process_messages_fn(_process_group_messages)
     _recover_pending_messages()
 
@@ -595,10 +694,16 @@ async def main() -> None:
     await _message_loop(shutdown_event)
 
     # Cleanup
+    for t in ipc_tasks:
+        t.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await t
+
     await proxy_runner.cleanup()
     await _queue.shutdown(10000)
     for ch in _channels:
         await ch.disconnect()
+    await _transport.close()
 
 
 # ---------------------------------------------------------------------------
@@ -627,6 +732,10 @@ class _SchedulerDepsImpl:
         group_folder: str,
     ) -> None:
         _queue.register_process(group_jid, proc, container_name, group_folder)
+
+    @property
+    def transport(self) -> NatsTransport | None:
+        return _transport
 
     async def send_message(self, jid: str, raw_text: str) -> None:
         channel = find_channel(_channels, jid)
@@ -671,9 +780,16 @@ class _IpcDepsImpl:
         available_groups: list[AvailableGroup],
         registered_jids: set[str],
     ) -> None:
-        write_groups_snapshot(group_folder, is_main, available_groups, registered_jids)
+        if _transport is not None:
+            t = asyncio.ensure_future(
+                write_groups_snapshot(_transport, group_folder, is_main, available_groups, registered_jids)
+            )
+            _bg_tasks.add(t)
+            t.add_done_callback(_bg_tasks.discard)
 
     def on_tasks_changed(self) -> None:
+        if _transport is None:
+            return
         tasks = get_all_tasks()
         task_rows: list[dict[str, object]] = [
             {
@@ -687,8 +803,15 @@ class _IpcDepsImpl:
             }
             for t in tasks
         ]
-        for group in _registered_groups.values():
-            write_tasks_snapshot(group.folder, group.is_main, task_rows)
+
+        async def _update_snapshots() -> None:
+            assert _transport is not None
+            for group in _registered_groups.values():
+                await write_tasks_snapshot(_transport, group.folder, group.is_main, task_rows)
+
+        t = asyncio.ensure_future(_update_snapshots())
+        _bg_tasks.add(t)
+        t.add_done_callback(_bg_tasks.discard)
 
 
 # ---------------------------------------------------------------------------

--- a/py/src/nanoclaw/main.py
+++ b/py/src/nanoclaw/main.py
@@ -428,7 +428,9 @@ async def _run_agent(
                 is_main=is_main,
                 assistant_name=ASSISTANT_NAME,
             ),
-            lambda proc, container_name: _queue.register_process(chat_jid, proc, container_name, group.folder),
+            lambda proc, container_name, job_id: _queue.register_process(
+                chat_jid, proc, container_name, group.folder, job_id
+            ),
             wrapped_on_output,
             transport=_transport,
         )
@@ -738,8 +740,9 @@ class _SchedulerDepsImpl:
         proc: object,
         container_name: str,
         group_folder: str,
+        job_id: str | None = None,
     ) -> None:
-        _queue.register_process(group_jid, proc, container_name, group_folder)
+        _queue.register_process(group_jid, proc, container_name, group_folder, job_id)
 
     @property
     def transport(self) -> NatsTransport | None:

--- a/py/src/nanoclaw/orchestration/task_scheduler.py
+++ b/py/src/nanoclaw/orchestration/task_scheduler.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
 
     from nanoclaw.container.scheduler import GroupQueue
+    from nanoclaw.ipc.nats_transport import NatsTransport
 
 logger = get_logger()
 
@@ -95,6 +96,8 @@ class SchedulerDependencies(Protocol):
         group_folder: str,
     ) -> None: ...
     def send_message(self, jid: str, text: str) -> Awaitable[None]: ...
+    @property
+    def transport(self) -> NatsTransport | None: ...
 
 
 _TASK_CLOSE_DELAY_S: float = 10.0
@@ -148,25 +151,28 @@ async def _run_task(
         )
         return
 
-    # Update tasks snapshot for container to read (filtered by group)
+    # Update tasks snapshot in NATS KV for container to read (Channel 6)
     is_main = group.is_main
-    all_tasks = get_all_tasks()
-    write_tasks_snapshot(
-        task.group_folder,
-        is_main,
-        [
-            {
-                "id": t.id,
-                "groupFolder": t.group_folder,
-                "prompt": t.prompt,
-                "schedule_type": t.schedule_type,
-                "schedule_value": t.schedule_value,
-                "status": t.status,
-                "next_run": t.next_run,
-            }
-            for t in all_tasks
-        ],
-    )
+    transport = deps.transport
+    if transport is not None:
+        all_tasks = get_all_tasks()
+        await write_tasks_snapshot(
+            transport,
+            task.group_folder,
+            is_main,
+            [
+                {
+                    "id": t.id,
+                    "groupFolder": t.group_folder,
+                    "prompt": t.prompt,
+                    "schedule_type": t.schedule_type,
+                    "schedule_value": t.schedule_value,
+                    "status": t.status,
+                    "next_run": t.next_run,
+                }
+                for t in all_tasks
+            ],
+        )
 
     result: str | None = None
     error: str | None = None
@@ -215,6 +221,7 @@ async def _run_task(
             ),
             lambda proc, container_name: deps.on_process(task.chat_jid, proc, container_name, task.group_folder),
             _on_output,
+            transport=transport,
         )
 
         if close_handle is not None:

--- a/py/src/nanoclaw/orchestration/task_scheduler.py
+++ b/py/src/nanoclaw/orchestration/task_scheduler.py
@@ -94,6 +94,7 @@ class SchedulerDependencies(Protocol):
         proc: object,
         container_name: str,
         group_folder: str,
+        job_id: str | None = None,
     ) -> None: ...
     def send_message(self, jid: str, text: str) -> Awaitable[None]: ...
     @property
@@ -219,7 +220,9 @@ async def _run_task(
                 is_scheduled_task=True,
                 assistant_name=ASSISTANT_NAME,
             ),
-            lambda proc, container_name: deps.on_process(task.chat_jid, proc, container_name, task.group_folder),
+            lambda proc, container_name, job_id: deps.on_process(
+                task.chat_jid, proc, container_name, task.group_folder, job_id
+            ),
             _on_output,
             transport=transport,
         )

--- a/py/tests/core/test_config.py
+++ b/py/tests/core/test_config.py
@@ -9,6 +9,7 @@ from nanoclaw.core.config import (
     GROUPS_DIR,
     IDLE_TIMEOUT,
     MAX_CONCURRENT_CONTAINERS,
+    NATS_URL,
     POLL_INTERVAL,
     TRIGGER_PATTERN,
 )
@@ -39,3 +40,8 @@ def test_trigger_pattern() -> None:
 def test_container_image() -> None:
     assert isinstance(CONTAINER_IMAGE, str)
     assert "nanoclaw" in CONTAINER_IMAGE
+
+
+def test_nats_url_default() -> None:
+    assert isinstance(NATS_URL, str)
+    assert NATS_URL.startswith("nats://")

--- a/py/tests/ipc/test_file_transport.py
+++ b/py/tests/ipc/test_file_transport.py
@@ -1,9 +1,9 @@
-"""Tests for nanoclaw.ipc."""
+"""Tests for nanoclaw.ipc task handler (extracted from file_transport)."""
 
 from __future__ import annotations
 
 from nanoclaw.db.sqlite import _init_test_database
-from nanoclaw.ipc.file_transport import process_task_ipc
+from nanoclaw.ipc.task_handler import process_task_ipc
 
 
 def setup_function() -> None:

--- a/py/tests/ipc/test_protocol.py
+++ b/py/tests/ipc/test_protocol.py
@@ -2,23 +2,7 @@
 
 from __future__ import annotations
 
-from nanoclaw.ipc.protocol import AgentInitData, IpcEnvelope
-
-
-def test_ipc_envelope_roundtrip() -> None:
-    """IpcEnvelope serializes and deserializes correctly."""
-    envelope = IpcEnvelope(
-        type="message",
-        group_folder="testgroup",
-        timestamp="2024-06-01T12:00:00Z",
-        payload={"text": "hello", "chatJid": "chat@test"},
-    )
-    data = envelope.serialize()
-    restored = IpcEnvelope.deserialize(data)
-    assert restored.type == envelope.type
-    assert restored.group_folder == envelope.group_folder
-    assert restored.timestamp == envelope.timestamp
-    assert restored.payload == envelope.payload
+from nanoclaw.ipc.protocol import AgentInitData
 
 
 def test_agent_init_data_roundtrip() -> None:
@@ -56,21 +40,6 @@ def test_agent_init_data_optional_fields() -> None:
     assert restored.session_id is None
     assert restored.is_scheduled_task is False
     assert restored.assistant_name is None
-
-
-def test_ipc_envelope_frozen() -> None:
-    """IpcEnvelope is immutable."""
-    envelope = IpcEnvelope(
-        type="test",
-        group_folder="g",
-        timestamp="t",
-        payload={},
-    )
-    try:
-        envelope.type = "other"  # type: ignore[misc]
-        raise AssertionError("Should have raised")
-    except AttributeError:
-        pass
 
 
 def test_agent_init_data_frozen() -> None:

--- a/py/tests/ipc/test_protocol.py
+++ b/py/tests/ipc/test_protocol.py
@@ -1,0 +1,88 @@
+"""Tests for nanoclaw.ipc.protocol -- IPC message serialization."""
+
+from __future__ import annotations
+
+from nanoclaw.ipc.protocol import AgentInitData, IpcEnvelope
+
+
+def test_ipc_envelope_roundtrip() -> None:
+    """IpcEnvelope serializes and deserializes correctly."""
+    envelope = IpcEnvelope(
+        type="message",
+        group_folder="testgroup",
+        timestamp="2024-06-01T12:00:00Z",
+        payload={"text": "hello", "chatJid": "chat@test"},
+    )
+    data = envelope.serialize()
+    restored = IpcEnvelope.deserialize(data)
+    assert restored.type == envelope.type
+    assert restored.group_folder == envelope.group_folder
+    assert restored.timestamp == envelope.timestamp
+    assert restored.payload == envelope.payload
+
+
+def test_agent_init_data_roundtrip() -> None:
+    """AgentInitData serializes and deserializes correctly."""
+    init = AgentInitData(
+        prompt="Hello world",
+        group_folder="mygroup",
+        chat_jid="tg:12345",
+        is_main=True,
+        session_id="sess-001",
+        is_scheduled_task=False,
+        assistant_name="Andy",
+    )
+    data = init.serialize()
+    restored = AgentInitData.deserialize(data)
+    assert restored.prompt == init.prompt
+    assert restored.group_folder == init.group_folder
+    assert restored.chat_jid == init.chat_jid
+    assert restored.is_main == init.is_main
+    assert restored.session_id == init.session_id
+    assert restored.is_scheduled_task == init.is_scheduled_task
+    assert restored.assistant_name == init.assistant_name
+
+
+def test_agent_init_data_optional_fields() -> None:
+    """AgentInitData handles missing optional fields."""
+    init = AgentInitData(
+        prompt="Test",
+        group_folder="group",
+        chat_jid="jid",
+        is_main=False,
+    )
+    data = init.serialize()
+    restored = AgentInitData.deserialize(data)
+    assert restored.session_id is None
+    assert restored.is_scheduled_task is False
+    assert restored.assistant_name is None
+
+
+def test_ipc_envelope_frozen() -> None:
+    """IpcEnvelope is immutable."""
+    envelope = IpcEnvelope(
+        type="test",
+        group_folder="g",
+        timestamp="t",
+        payload={},
+    )
+    try:
+        envelope.type = "other"  # type: ignore[misc]
+        raise AssertionError("Should have raised")
+    except AttributeError:
+        pass
+
+
+def test_agent_init_data_frozen() -> None:
+    """AgentInitData is immutable."""
+    init = AgentInitData(
+        prompt="p",
+        group_folder="g",
+        chat_jid="j",
+        is_main=True,
+    )
+    try:
+        init.prompt = "other"  # type: ignore[misc]
+        raise AssertionError("Should have raised")
+    except AttributeError:
+        pass

--- a/py/tests/test_e2e.py
+++ b/py/tests/test_e2e.py
@@ -7,7 +7,6 @@ Uses in-memory SQLite, real GroupQueue, real message routing.
 from __future__ import annotations
 
 import asyncio
-import json
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -72,7 +71,6 @@ def e2e_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr("nanoclaw.core.config.GROUPS_DIR", groups_dir)
     monkeypatch.setattr("nanoclaw.core.config.STORE_DIR", store_dir)
     monkeypatch.setattr("nanoclaw.core.config.POLL_INTERVAL", 0.05)
-    monkeypatch.setattr("nanoclaw.core.config.IPC_POLL_INTERVAL", 0.05)
     monkeypatch.setattr("nanoclaw.core.config.SCHEDULER_POLL_INTERVAL", 0.05)
     monkeypatch.setattr("nanoclaw.core.config.IDLE_TIMEOUT", 1000)
     monkeypatch.setattr("nanoclaw.core.config.TIMEZONE", "UTC")
@@ -82,7 +80,6 @@ def e2e_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # Also patch in modules that import these at module-load time
     monkeypatch.setattr("nanoclaw.core.group_folder.DATA_DIR", data_dir)
     monkeypatch.setattr("nanoclaw.core.group_folder.GROUPS_DIR", groups_dir)
-    monkeypatch.setattr("nanoclaw.container.scheduler.DATA_DIR", data_dir)
     monkeypatch.setattr("nanoclaw.main.TIMEZONE", "UTC")
     monkeypatch.setattr("nanoclaw.main.ASSISTANT_NAME", "Andy")
     monkeypatch.setattr("nanoclaw.main.TRIGGER_PATTERN", re.compile(r"^@Andy\b", re.IGNORECASE))
@@ -115,6 +112,7 @@ def make_container_mock(
         inp: object,
         on_process: Callable[..., None],
         on_output: Callable[..., Awaitable[None]] | None = None,
+        transport: object | None = None,
     ) -> ContainerOutput:
         captured_inputs.append(inp)
         on_process(object(), "test-container-mock")
@@ -371,6 +369,7 @@ async def test_format_messages_xml(e2e_env: Path) -> None:
         inp: ContainerInput,
         on_process: Callable[..., None],
         on_output: Callable[..., Awaitable[None]] | None = None,
+        transport: object | None = None,
     ) -> ContainerOutput:
         captured_prompts.append(inp.prompt)
         on_process(object(), "test-container")
@@ -440,7 +439,7 @@ async def test_ipc_task_scheduling(e2e_env: Path) -> None:
     """IPC task file → creates scheduled task in DB."""
     from nanoclaw.core.types import RegisteredGroup
     from nanoclaw.db.sqlite import get_task_by_id
-    from nanoclaw.ipc.file_transport import process_task_ipc
+    from nanoclaw.ipc.task_handler import process_task_ipc
 
     registered = {
         "chat@test": RegisteredGroup(
@@ -500,13 +499,10 @@ async def test_ipc_task_scheduling(e2e_env: Path) -> None:
     assert len(tasks_changed) == 1
 
 
-async def test_ipc_message_routing(e2e_env: Path) -> None:
-    """IPC message file in group dir → routed to channel.send_message."""
-    data_dir = e2e_env / "data"
-    ipc_dir = data_dir / "ipc" / "testgroup" / "messages"
-    ipc_dir.mkdir(parents=True)
-
+async def test_ipc_task_handler_message_auth(e2e_env: Path) -> None:
+    """IPC task handler processes messages with proper authorization."""
     from nanoclaw.core.types import RegisteredGroup
+    from nanoclaw.ipc.task_handler import process_task_ipc
 
     registered = {
         "chat@test": RegisteredGroup(
@@ -517,12 +513,11 @@ async def test_ipc_message_routing(e2e_env: Path) -> None:
             is_main=True,
         )
     }
-
-    sent_messages: list[tuple[str, str]] = []
+    tasks_changed: list[bool] = []
 
     class FakeDeps:
         async def send_message(self, jid: str, text: str) -> None:
-            sent_messages.append((jid, text))
+            pass
 
         def registered_groups(self) -> dict[str, RegisteredGroup]:
             return registered
@@ -540,21 +535,24 @@ async def test_ipc_message_routing(e2e_env: Path) -> None:
             pass
 
         def on_tasks_changed(self) -> None:
-            pass
-
-    # Write an IPC message file
-    msg_file = ipc_dir / "001.json"
-    msg_file.write_text(json.dumps({"type": "message", "chatJid": "chat@test", "text": "Hello from IPC!"}))
-
-    from nanoclaw.ipc.file_transport import _process_ipc_files
+            tasks_changed.append(True)
 
     deps = FakeDeps()
-    ipc_base = data_dir / "ipc"
-    await _process_ipc_files(ipc_base, deps)  # type: ignore[arg-type]
 
-    assert len(sent_messages) == 1
-    assert sent_messages[0] == ("chat@test", "Hello from IPC!")
-    assert not msg_file.exists()  # File consumed
+    # Non-main trying to schedule for another group should be blocked
+    await process_task_ipc(
+        {
+            "type": "schedule_task",
+            "prompt": "Should be blocked",
+            "schedule_type": "cron",
+            "schedule_value": "0 9 * * *",
+            "targetJid": "chat@test",
+        },
+        "other-group",
+        False,  # not main
+        deps,  # type: ignore[arg-type]
+    )
+    assert len(tasks_changed) == 0  # Blocked
 
 
 async def test_queue_concurrency(e2e_env: Path) -> None:

--- a/py/tests/test_e2e.py
+++ b/py/tests/test_e2e.py
@@ -115,7 +115,7 @@ def make_container_mock(
         transport: object | None = None,
     ) -> ContainerOutput:
         captured_inputs.append(inp)
-        on_process(object(), "test-container-mock")
+        on_process(object(), "test-container-mock", "test-job")
 
         output = ContainerOutput(
             status=status,  # type: ignore[arg-type]
@@ -372,7 +372,7 @@ async def test_format_messages_xml(e2e_env: Path) -> None:
         transport: object | None = None,
     ) -> ContainerOutput:
         captured_prompts.append(inp.prompt)
-        on_process(object(), "test-container")
+        on_process(object(), "test-container", "test-job")
         if on_output:
             await on_output(ContainerOutput(status="success", result="OK"))
         return ContainerOutput(status="success", result=None)

--- a/py/tests/test_user_flow.py
+++ b/py/tests/test_user_flow.py
@@ -190,7 +190,7 @@ def make_agent_mock(
         transport: object | None = None,
     ) -> ContainerOutput:
         captured.append(inp)
-        on_process(object(), "mock-container")
+        on_process(object(), "mock-container", "test-job")
 
         output = ContainerOutput(
             status="success",
@@ -642,7 +642,7 @@ class TestScenarioErrorRecovery:
             on_output: Callable[..., Awaitable[None]] | None = None,
             transport: object | None = None,
         ) -> ContainerOutput:
-            on_process(object(), "crash-container")
+            on_process(object(), "crash-container", "test-job")
             if on_output:
                 await on_output(ContainerOutput(status="error", result=None, error="Segfault"))
             return ContainerOutput(status="error", result=None, error="Segfault")
@@ -673,7 +673,7 @@ class TestScenarioErrorRecovery:
             on_output: Callable[..., Awaitable[None]] | None = None,
             transport: object | None = None,
         ) -> ContainerOutput:
-            on_process(object(), "partial-container")
+            on_process(object(), "partial-container", "test-job")
             if on_output:
                 # First: send a successful partial output
                 await on_output(

--- a/py/tests/test_user_flow.py
+++ b/py/tests/test_user_flow.py
@@ -16,7 +16,6 @@ Mocks are limited to Docker/container spawning — everything else runs for real
 from __future__ import annotations
 
 import asyncio
-import json
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -82,7 +81,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr("nanoclaw.core.config.GROUPS_DIR", groups_dir)
     monkeypatch.setattr("nanoclaw.core.config.STORE_DIR", store_dir)
     monkeypatch.setattr("nanoclaw.core.config.POLL_INTERVAL", 0.05)
-    monkeypatch.setattr("nanoclaw.core.config.IPC_POLL_INTERVAL", 0.05)
     monkeypatch.setattr("nanoclaw.core.config.SCHEDULER_POLL_INTERVAL", 0.05)
     monkeypatch.setattr("nanoclaw.core.config.IDLE_TIMEOUT", 2000)
     monkeypatch.setattr("nanoclaw.core.config.TIMEZONE", "UTC")
@@ -95,7 +93,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # Patch modules that captured config at import time
     monkeypatch.setattr("nanoclaw.core.group_folder.DATA_DIR", data_dir)
     monkeypatch.setattr("nanoclaw.core.group_folder.GROUPS_DIR", groups_dir)
-    monkeypatch.setattr("nanoclaw.container.scheduler.DATA_DIR", data_dir)
     monkeypatch.setattr("nanoclaw.main.TIMEZONE", "UTC")
     monkeypatch.setattr("nanoclaw.main.ASSISTANT_NAME", "Andy")
     monkeypatch.setattr(
@@ -190,6 +187,7 @@ def make_agent_mock(
         inp: object,
         on_process: Callable[..., None],
         on_output: Callable[..., Awaitable[None]] | None = None,
+        transport: object | None = None,
     ) -> ContainerOutput:
         captured.append(inp)
         on_process(object(), "mock-container")
@@ -390,7 +388,7 @@ class TestScenarioIPCFromContainer:
         """Agent writes a task IPC file → task created in DB."""
         from nanoclaw.core.types import RegisteredGroup
         from nanoclaw.db.sqlite import get_task_by_id
-        from nanoclaw.ipc.file_transport import process_task_ipc
+        from nanoclaw.ipc.task_handler import process_task_ipc
 
         registered = {
             "tg@test": RegisteredGroup(
@@ -448,14 +446,11 @@ class TestScenarioIPCFromContainer:
         assert task.group_folder == "testgroup"
         assert len(tasks_changed) == 1
 
-    async def test_ipc_message_routing(self, env: Path) -> None:
-        """Agent writes IPC message file → routed to correct channel."""
-        data_dir = env / "data"
-        ipc_dir = data_dir / "ipc" / "mygroup" / "messages"
-        ipc_dir.mkdir(parents=True)
-
-        from nanoclaw.core.types import RegisteredGroup
-        from nanoclaw.ipc.file_transport import _process_ipc_files
+    async def test_ipc_task_pause_resume(self, env: Path) -> None:
+        """Agent pauses and resumes a task via IPC handler."""
+        from nanoclaw.core.types import RegisteredGroup, ScheduledTask
+        from nanoclaw.db.sqlite import create_task, get_task_by_id
+        from nanoclaw.ipc.task_handler import process_task_ipc
 
         registered = {
             "tg@test": RegisteredGroup(
@@ -466,11 +461,11 @@ class TestScenarioIPCFromContainer:
                 is_main=True,
             )
         }
-        sent: list[tuple[str, str]] = []
+        tasks_changed: list[bool] = []
 
         class FakeDeps:
             async def send_message(self, jid: str, text: str) -> None:
-                sent.append((jid, text))
+                pass
 
             def registered_groups(self) -> dict[str, RegisteredGroup]:
                 return registered
@@ -488,25 +483,47 @@ class TestScenarioIPCFromContainer:
                 pass
 
             def on_tasks_changed(self) -> None:
-                pass
+                tasks_changed.append(True)
 
-        # Agent writes an IPC message
-        msg_file = ipc_dir / "001.json"
-        msg_file.write_text(
-            json.dumps(
-                {
-                    "type": "message",
-                    "chatJid": "tg@test",
-                    "text": "Here's the daily report you asked for!",
-                }
+        # Create a task first
+        create_task(
+            ScheduledTask(
+                id="task-pause-test",
+                group_folder="mygroup",
+                chat_jid="tg@test",
+                prompt="Test task",
+                schedule_type="cron",
+                schedule_value="0 9 * * *",
+                context_mode="isolated",
+                next_run="2024-06-01T09:00:00Z",
+                status="active",
+                created_at="2024-01-01T00:00:00Z",
             )
         )
 
-        await _process_ipc_files(data_dir / "ipc", FakeDeps())  # type: ignore[arg-type]
+        # Pause it
+        await process_task_ipc(
+            {"type": "pause_task", "taskId": "task-pause-test"},
+            "mygroup",
+            True,
+            FakeDeps(),  # type: ignore[arg-type]
+        )
+        task = get_task_by_id("task-pause-test")
+        assert task is not None
+        assert task.status == "paused"
+        assert len(tasks_changed) == 1
 
-        assert len(sent) == 1
-        assert sent[0] == ("tg@test", "Here's the daily report you asked for!")
-        assert not msg_file.exists()  # consumed
+        # Resume it
+        await process_task_ipc(
+            {"type": "resume_task", "taskId": "task-pause-test"},
+            "mygroup",
+            True,
+            FakeDeps(),  # type: ignore[arg-type]
+        )
+        task = get_task_by_id("task-pause-test")
+        assert task is not None
+        assert task.status == "active"
+        assert len(tasks_changed) == 2
 
 
 class TestScenarioTaskScheduling:
@@ -623,6 +640,7 @@ class TestScenarioErrorRecovery:
             inp: object,
             on_process: Callable[..., None],
             on_output: Callable[..., Awaitable[None]] | None = None,
+            transport: object | None = None,
         ) -> ContainerOutput:
             on_process(object(), "crash-container")
             if on_output:
@@ -653,6 +671,7 @@ class TestScenarioErrorRecovery:
             inp: object,
             on_process: Callable[..., None],
             on_output: Callable[..., Awaitable[None]] | None = None,
+            transport: object | None = None,
         ) -> ContainerOutput:
             on_process(object(), "partial-container")
             if on_output:


### PR DESCRIPTION
## Summary

- Replace all 6 IPC channels (stdin/stdout/file-based) between Orchestrator and Agent with NATS (KV Store + JetStream + request-reply)
- Add `nats-py>=2.9` dependency, `NATS_URL` config, `JOB_ID` per-container env var
- Delete `file_transport.py`, extract task handler logic into `task_handler.py`
- Add `docker-compose.dev.yml` for NATS dev setup with JetStream

### Channel-by-channel migration

| # | Channel | Before | After |
|---|---------|--------|-------|
| 1 | Initial input (Orch→Agent) | stdin JSON | KV `agent-init.{jobId}` |
| 2 | Streaming results (Agent→Orch) | stdout markers | JetStream `agent.{jobId}.results` |
| 3 | Follow-up + close (Orch→Agent) | file polling + sentinel | JetStream `agent.{jobId}.input` + request-reply `.close` |
| 4 | Messages (Agent→Orch) | `messages/*.json` | JetStream `agent.{jobId}.messages` |
| 5 | Tasks (Agent→Orch) | `tasks/*.json` | JetStream `agent.{jobId}.tasks` |
| 6 | Snapshots (Orch→Agent) | `current_tasks.json` / `available_groups.json` | KV `snapshots.{group}.tasks` / `.groups` |

### Files changed

- **New**: `ipc/protocol.py`, `ipc/nats_transport.py`, `ipc/task_handler.py`, `docker-compose.dev.yml`
- **Deleted**: `ipc/file_transport.py`
- **Modified**: `container/runner.py`, `container/scheduler.py`, `main.py`, `core/config.py`, `orchestration/task_scheduler.py`, `agent_runner/main.py`, `agent_runner/ipc_mcp.py`

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy --strict src/nanoclaw` passes (0 errors)
- [x] `pytest --cov --cov-fail-under=80` passes (138/139, 83% coverage; 1 pre-existing slack test failure)
- [x] New unit tests for `IpcEnvelope` and `AgentInitData` serialization
- [x] Existing e2e and integration tests updated and passing
- [ ] Manual test with NATS server (`docker compose -f docker-compose.dev.yml up`)

Closes #2