### PR TITLE
refactor: AgentExecutor + ContainerRuntime abstraction (Step 3)

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-telegram-bot>=22.7",
     "slack-bolt>=1.27.0",
     "nats-py>=2.9",
+    "aiodocker>=0.23",
 ]
 
 [project.scripts]
@@ -60,6 +61,8 @@ omit = [
     "*/nanoclaw/orchestration/remote_control.py",
     "*/nanoclaw/channels/slack.py",
     "*/nanoclaw/channels/telegram.py",
+    "*/nanoclaw/agent/container_executor.py",
+    "*/nanoclaw/container/docker_runtime.py",
 ]
 
 [tool.coverage.report]

--- a/py/src/nanoclaw/agent/__init__.py
+++ b/py/src/nanoclaw/agent/__init__.py
@@ -1,1 +1,19 @@
-"""Agent execution layer — placeholder for Step 3."""
+"""Agent execution layer -- protocols, data types, and executor implementations."""
+
+from nanoclaw.agent.executor import (
+    CLAUDE_CODE_BACKEND,
+    PIMONO_BACKEND,
+    AgentBackendConfig,
+    AgentExecutor,
+    AgentInput,
+    AgentOutput,
+)
+
+__all__ = [
+    "CLAUDE_CODE_BACKEND",
+    "PIMONO_BACKEND",
+    "AgentBackendConfig",
+    "AgentExecutor",
+    "AgentInput",
+    "AgentOutput",
+]

--- a/py/src/nanoclaw/agent/__init__.py
+++ b/py/src/nanoclaw/agent/__init__.py
@@ -1,5 +1,6 @@
 """Agent execution layer -- protocols, data types, and executor implementations."""
 
+from nanoclaw.agent.container_executor import ContainerAgentExecutor
 from nanoclaw.agent.executor import (
     CLAUDE_CODE_BACKEND,
     PIMONO_BACKEND,
@@ -16,4 +17,5 @@ __all__ = [
     "AgentExecutor",
     "AgentInput",
     "AgentOutput",
+    "ContainerAgentExecutor",
 ]

--- a/py/src/nanoclaw/agent/container_executor.py
+++ b/py/src/nanoclaw/agent/container_executor.py
@@ -227,8 +227,8 @@ class ContainerAgentExecutor:
                         )
                     else:
                         stderr_buf += chunk
-            except (OSError, RuntimeError):
-                pass
+            except (OSError, RuntimeError) as err:
+                logger.debug("Stderr read stopped", error=str(err))
 
         # Run readers concurrently
         tasks: list[asyncio.Task[None]] = [asyncio.create_task(_read_stderr())]

--- a/py/src/nanoclaw/agent/container_executor.py
+++ b/py/src/nanoclaw/agent/container_executor.py
@@ -1,0 +1,375 @@
+"""Container-based agent executor.
+
+Moves orchestration logic from runner.run_container_agent() into a class
+that uses ContainerRuntime (Docker API) instead of subprocess calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import re
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from nanoclaw.agent.executor import AgentBackendConfig, AgentInput, AgentOutput
+from nanoclaw.container.runner import (
+    build_container_spec,
+    build_volume_mounts,
+)
+from nanoclaw.core.config import (
+    CONTAINER_MAX_OUTPUT_SIZE,
+    CONTAINER_TIMEOUT,
+    IDLE_TIMEOUT,
+)
+from nanoclaw.core.group_folder import resolve_group_folder_path
+from nanoclaw.core.logger import get_logger
+from nanoclaw.ipc.protocol import AgentInitData
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from nanoclaw.container.runtime import ContainerHandle, ContainerRuntime
+    from nanoclaw.core.types import RegisteredGroup
+    from nanoclaw.ipc.nats_transport import NatsTransport
+
+logger = get_logger()
+
+
+def _parse_container_output(raw: dict[str, object]) -> AgentOutput:
+    """Parse a raw JSON dict into an AgentOutput, handling camelCase keys."""
+    result_val = raw.get("result")
+    new_sid = raw.get("newSessionId")
+    err_val = raw.get("error")
+    return AgentOutput(
+        status=str(raw.get("status", "error")),  # type: ignore[arg-type]
+        result=str(result_val) if result_val is not None else None,
+        new_session_id=str(new_sid) if new_sid is not None else None,
+        error=str(err_val) if err_val is not None else None,
+    )
+
+
+class ContainerAgentExecutor:
+    """Runs agents in containers via ContainerRuntime.
+
+    Logic moved from run_container_agent(), using ContainerRuntime.run(spec)
+    instead of subprocess.  Backend config selects image, entrypoint, mounts.
+    """
+
+    def __init__(
+        self,
+        config: AgentBackendConfig,
+        runtime: ContainerRuntime,
+        transport: NatsTransport,
+        registered_groups: Callable[[], dict[str, RegisteredGroup]],
+    ) -> None:
+        self._config = config
+        self._runtime = runtime
+        self._transport = transport
+        self._registered_groups = registered_groups
+
+    @property
+    def name(self) -> str:
+        return self._config.name
+
+    async def execute(
+        self,
+        inp: AgentInput,
+        on_process: Callable[[ContainerHandle, str, str], None],
+        on_output: Callable[[AgentOutput], Awaitable[None]] | None = None,
+    ) -> AgentOutput:
+        """Run an agent in a container. Replaces run_container_agent()."""
+        start_time = time.monotonic()
+        start_epoch_ms = int(time.time() * 1000)
+
+        group_dir = resolve_group_folder_path(inp.group_folder)
+        group_dir.mkdir(parents=True, exist_ok=True)
+
+        job_id = f"{inp.group_folder}-{uuid.uuid4().hex[:12]}"
+
+        # Look up group for mount computation
+        groups = self._registered_groups()
+        group = next((g for g in groups.values() if g.folder == inp.group_folder), None)
+        if group is None:
+            return AgentOutput(
+                status="error",
+                result=None,
+                error=f"Group not found: {inp.group_folder}",
+            )
+
+        mounts = build_volume_mounts(group, inp.is_main, self._config)
+        safe_name = re.sub(r"[^a-zA-Z0-9-]", "-", inp.group_folder)
+        container_name = f"nanoclaw-{safe_name}-{start_epoch_ms}"
+
+        spec = build_container_spec(mounts, container_name, job_id, self._config)
+
+        logger.info(
+            "Spawning container agent",
+            group=group.name,
+            container_name=container_name,
+            job_id=job_id,
+            mount_count=len(mounts),
+            is_main=inp.is_main,
+            backend=self._config.name,
+        )
+
+        logs_dir = group_dir / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Channel 1: Write initial input to KV before starting container
+        kv_init = await self._transport.js.key_value("agent-init")
+        agent_init = AgentInitData(
+            prompt=inp.prompt,
+            group_folder=inp.group_folder,
+            chat_jid=inp.chat_jid,
+            is_main=inp.is_main,
+            session_id=inp.session_id,
+            is_scheduled_task=inp.is_scheduled_task,
+            assistant_name=inp.assistant_name,
+            system_prompt=inp.system_prompt,
+            role_config=inp.role_config,
+        )
+        await kv_init.put(job_id, agent_init.serialize())
+
+        # Start container via ContainerRuntime (NOT subprocess)
+        handle = await self._runtime.run(spec)
+        on_process(handle, container_name, job_id)
+
+        stderr_buf = ""
+        stderr_truncated = False
+        new_session_id: str | None = None
+        had_streaming_output = False
+        timed_out = False
+
+        config_timeout = (
+            group.container_config.timeout if group.container_config else CONTAINER_TIMEOUT
+        ) or CONTAINER_TIMEOUT
+        timeout_ms = max(config_timeout, IDLE_TIMEOUT + 30_000)
+        timeout_s = timeout_ms / 1000.0
+
+        # Timeout management
+        activity_event = asyncio.Event()
+
+        async def _timeout_watcher() -> None:
+            nonlocal timed_out
+            while True:
+                activity_event.clear()
+                try:
+                    await asyncio.wait_for(activity_event.wait(), timeout=timeout_s)
+                except TimeoutError:
+                    timed_out = True
+                    logger.error(
+                        "Container timeout, stopping gracefully",
+                        group=group.name,
+                        container_name=container_name,
+                    )
+                    with contextlib.suppress(OSError):
+                        await handle.stop(timeout=15)
+                    return
+
+        timeout_task = asyncio.create_task(_timeout_watcher())
+
+        # Channel 2: Subscribe to JetStream for streaming results
+        results_sub = None
+        if on_output is not None:
+            results_sub = await self._transport.js.subscribe(f"agent.{job_id}.results")
+
+        async def _read_results() -> None:
+            nonlocal new_session_id, had_streaming_output
+            if results_sub is None:
+                return
+            async for msg in results_sub.messages:
+                try:
+                    raw = json.loads(msg.data)
+                    parsed = _parse_container_output(raw)
+                    if parsed.new_session_id:
+                        new_session_id = parsed.new_session_id
+                    had_streaming_output = True
+                    activity_event.set()
+                    if on_output is not None:
+                        await on_output(parsed)
+                    await msg.ack()
+                except (json.JSONDecodeError, KeyError, TypeError) as err:
+                    logger.warning(
+                        "Failed to parse streamed output",
+                        group=group.name,
+                        error=str(err),
+                    )
+                    await msg.ack()
+
+        async def _read_stderr() -> None:
+            nonlocal stderr_buf, stderr_truncated
+            try:
+                async for chunk_bytes in handle.read_stderr():
+                    chunk = (
+                        chunk_bytes.decode("utf-8", errors="replace")
+                        if isinstance(chunk_bytes, bytes)
+                        else str(chunk_bytes)
+                    )
+                    lines = chunk.strip().split("\n")
+                    for line in lines:
+                        if line:
+                            logger.debug(line, container=inp.group_folder)
+                    if stderr_truncated:
+                        continue
+                    remaining = CONTAINER_MAX_OUTPUT_SIZE - len(stderr_buf)
+                    if len(chunk) > remaining:
+                        stderr_buf += chunk[:remaining]
+                        stderr_truncated = True
+                        logger.warning(
+                            "Container stderr truncated due to size limit",
+                            group=group.name,
+                            size=len(stderr_buf),
+                        )
+                    else:
+                        stderr_buf += chunk
+            except (OSError, RuntimeError):
+                pass
+
+        # Run readers concurrently
+        tasks: list[asyncio.Task[None]] = [asyncio.create_task(_read_stderr())]
+        if results_sub is not None:
+            tasks.append(asyncio.create_task(_read_results()))
+
+        # Wait for container to exit
+        code = await handle.wait()
+
+        # Cancel the results subscription and readers
+        if results_sub is not None:
+            await results_sub.unsubscribe()
+        for t in tasks:
+            t.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await t
+
+        timeout_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await timeout_task
+
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+
+        if timed_out:
+            ts = datetime.now(UTC).isoformat().replace(":", "-").replace(".", "-")
+            timeout_log = logs_dir / f"container-{ts}.log"
+            timeout_log.write_text(
+                "\n".join(
+                    [
+                        "=== Container Run Log (TIMEOUT) ===",
+                        f"Timestamp: {datetime.now(UTC).isoformat()}",
+                        f"Group: {group.name}",
+                        f"Container: {container_name}",
+                        f"Job ID: {job_id}",
+                        f"Duration: {duration_ms}ms",
+                        f"Exit Code: {code}",
+                        f"Had Streaming Output: {had_streaming_output}",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            if had_streaming_output:
+                logger.info(
+                    "Container timed out after output (idle cleanup)",
+                    group=group.name,
+                    container_name=container_name,
+                    duration=duration_ms,
+                    code=code,
+                )
+                return AgentOutput(
+                    status="success",
+                    result=None,
+                    new_session_id=new_session_id,
+                )
+
+            logger.error(
+                "Container timed out with no output",
+                group=group.name,
+                container_name=container_name,
+                duration=duration_ms,
+                code=code,
+            )
+            return AgentOutput(
+                status="error",
+                result=None,
+                error=f"Container timed out after {config_timeout}ms",
+            )
+
+        timestamp = datetime.now(UTC).isoformat().replace(":", "-").replace(".", "-")
+        log_file = logs_dir / f"container-{timestamp}.log"
+        is_verbose = os.environ.get("LOG_LEVEL") in ("debug", "trace")
+
+        log_lines: list[str] = [
+            "=== Container Run Log ===",
+            f"Timestamp: {datetime.now(UTC).isoformat()}",
+            f"Group: {group.name}",
+            f"IsMain: {inp.is_main}",
+            f"Job ID: {job_id}",
+            f"Duration: {duration_ms}ms",
+            f"Exit Code: {code}",
+            f"Stderr Truncated: {stderr_truncated}",
+            "",
+        ]
+
+        is_error = code != 0
+
+        if is_verbose or is_error:
+            log_lines.extend(
+                [
+                    "=== Input Summary ===",
+                    f"Prompt length: {len(inp.prompt)} chars",
+                    f"Session ID: {inp.session_id or 'new'}",
+                    f"Job ID: {job_id}",
+                    "",
+                    "=== Mounts ===",
+                    "\n".join(f"{m.host_path} -> {m.container_path}{' (ro)' if m.readonly else ''}" for m in mounts),
+                    "",
+                    f"=== Stderr{' (TRUNCATED)' if stderr_truncated else ''} ===",
+                    stderr_buf,
+                ]
+            )
+        else:
+            log_lines.extend(
+                [
+                    "=== Input Summary ===",
+                    f"Prompt length: {len(inp.prompt)} chars",
+                    f"Session ID: {inp.session_id or 'new'}",
+                    "",
+                    "=== Mounts ===",
+                    "\n".join(f"{m.container_path}{' (ro)' if m.readonly else ''}" for m in mounts),
+                    "",
+                ]
+            )
+
+        log_file.write_text("\n".join(log_lines), encoding="utf-8")
+        logger.debug("Container log written", log_file=str(log_file), verbose=is_verbose)
+
+        if code != 0:
+            logger.error(
+                "Container exited with error",
+                group=group.name,
+                code=code,
+                duration=duration_ms,
+                stderr=stderr_buf,
+                log_file=str(log_file),
+            )
+            return AgentOutput(
+                status="error",
+                result=None,
+                error=f"Container exited with code {code}: {stderr_buf[-200:]}",
+            )
+
+        logger.info(
+            "Container completed",
+            group=group.name,
+            duration=duration_ms,
+            new_session_id=new_session_id,
+        )
+        return AgentOutput(
+            status="success",
+            result=None,
+            new_session_id=new_session_id,
+        )

--- a/py/src/nanoclaw/agent/executor.py
+++ b/py/src/nanoclaw/agent/executor.py
@@ -1,0 +1,84 @@
+"""Agent execution protocol and data types.
+
+Defines AgentInput, AgentOutput, AgentBackendConfig, and the AgentExecutor
+protocol.  Concrete implementations (e.g. ContainerAgentExecutor) live in
+separate modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from nanoclaw.container.runtime import ContainerHandle
+
+
+@dataclass(frozen=True)
+class AgentInput:
+    """Input to an agent execution."""
+
+    prompt: str
+    group_folder: str
+    chat_jid: str
+    is_main: bool
+    session_id: str | None = None
+    is_scheduled_task: bool = False
+    assistant_name: str | None = None
+    system_prompt: str | None = None
+    role_config: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class AgentOutput:
+    """Output from an agent execution."""
+
+    status: Literal["success", "error"]
+    result: str | None
+    new_session_id: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentBackendConfig:
+    """Distinguishes different Agent backends.
+
+    A single ContainerAgentExecutor uses this config to select the right
+    image, entrypoint, and volume mounts for each backend.
+    """
+
+    name: str
+    image: str
+    entrypoint: list[str] | None = None
+    extra_mounts: list[tuple[str, str, bool]] = field(default_factory=list)
+    extra_env: dict[str, str] = field(default_factory=dict)
+    skip_claude_session: bool = False
+
+
+CLAUDE_CODE_BACKEND = AgentBackendConfig(
+    name="claude-code",
+    image="nanoclaw-agent:latest",
+)
+
+PIMONO_BACKEND = AgentBackendConfig(
+    name="pi-mono",
+    image="ppi-agent:latest",
+    entrypoint=["python", "-m", "ppi.coding_agent", "--mode", "nanoclaw"],
+    skip_claude_session=True,
+)
+
+
+class AgentExecutor(Protocol):
+    """Protocol for agent execution backends."""
+
+    @property
+    def name(self) -> str: ...
+
+    async def execute(
+        self,
+        inp: AgentInput,
+        on_process: Callable[[ContainerHandle, str, str], None],
+        on_output: Callable[[AgentOutput], Awaitable[None]] | None = None,
+    ) -> AgentOutput: ...

--- a/py/src/nanoclaw/container/docker_runtime.py
+++ b/py/src/nanoclaw/container/docker_runtime.py
@@ -1,0 +1,190 @@
+"""Docker Engine API implementation using aiodocker.
+
+Replaces all subprocess-based Docker calls with the Docker Engine API.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+import aiodocker
+import aiodocker.containers
+import aiodocker.exceptions
+
+from nanoclaw.core.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from nanoclaw.container.runtime import ContainerSpec, VolumeMount
+
+logger = get_logger()
+
+# Memory suffix multipliers
+_MEM_SUFFIXES: dict[str, int] = {
+    "b": 1,
+    "k": 1024,
+    "m": 1024**2,
+    "g": 1024**3,
+}
+
+
+def _parse_memory(value: str) -> int:
+    """Parse a memory string like '512m' into bytes."""
+    value = value.strip().lower()
+    for suffix, multiplier in _MEM_SUFFIXES.items():
+        if value.endswith(suffix):
+            return int(value[: -len(suffix)]) * multiplier
+    return int(value)
+
+
+def _mounts_to_binds(mounts: list[VolumeMount]) -> list[str]:
+    """Convert VolumeMount list to Docker bind strings."""
+    return [f"{m.host_path}:{m.container_path}:{'ro' if m.readonly else 'rw'}" for m in mounts]
+
+
+class DockerContainerHandle:
+    """Handle to a running Docker container."""
+
+    def __init__(self, container: aiodocker.containers.DockerContainer, container_name: str) -> None:
+        self._container = container
+        self._name = container_name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def pid(self) -> int:
+        return hash(self._name) & 0x7FFFFFFF
+
+    async def wait(self) -> int:
+        result: dict[str, Any] = await self._container.wait()
+        return int(result.get("StatusCode", -1))
+
+    async def stop(self, timeout: int = 1) -> None:
+        with contextlib.suppress(aiodocker.exceptions.DockerError):
+            await self._container.stop(t=timeout)
+        with contextlib.suppress(aiodocker.exceptions.DockerError):
+            await self._container.delete(force=True)
+
+    async def read_stderr(self) -> AsyncIterator[bytes]:
+        async for line in self._container.log(stdout=False, stderr=True, follow=True):
+            yield line.encode() if isinstance(line, str) else line
+
+
+class DockerRuntime:
+    """Docker Engine API implementation using aiodocker."""
+
+    def __init__(self) -> None:
+        self._client: aiodocker.Docker | None = None
+
+    @property
+    def name(self) -> str:
+        return "docker"
+
+    async def ensure_available(self) -> None:
+        self._client = aiodocker.Docker()
+        try:
+            await self._client.system.info()
+            logger.debug("Docker runtime available")
+        except (OSError, aiodocker.exceptions.DockerError) as exc:
+            await self._client.close()
+            self._client = None
+            msg = (
+                "\n================================================================\n"
+                "  FATAL: Docker daemon is not reachable                         \n"
+                "                                                                \n"
+                "  Agents cannot run without Docker. To fix:                     \n"
+                "  1. Ensure Docker is installed and running                     \n"
+                "  2. Run: docker info                                           \n"
+                "  3. Restart NanoClaw                                           \n"
+                "================================================================\n"
+            )
+            raise RuntimeError(msg) from exc
+
+    def _ensure_client(self) -> aiodocker.Docker:
+        if self._client is None:
+            msg = "DockerRuntime.ensure_available() must be called first"
+            raise RuntimeError(msg)
+        return self._client
+
+    async def run(self, spec: ContainerSpec) -> DockerContainerHandle:
+        client = self._ensure_client()
+        config = self._spec_to_config(spec)
+
+        # Remove existing container with same name (if any)
+        with contextlib.suppress(aiodocker.exceptions.DockerError):
+            old = client.containers.container(spec.name)
+            await old.delete(force=True)
+
+        container = await client.containers.create_or_replace(
+            name=spec.name,
+            config=config,
+        )
+        await container.start()
+        return DockerContainerHandle(container, spec.name)
+
+    async def stop(self, name: str, timeout: int = 1) -> None:
+        client = self._ensure_client()
+        container = client.containers.container(name)
+        with contextlib.suppress(aiodocker.exceptions.DockerError):
+            await container.stop(t=timeout)
+        with contextlib.suppress(aiodocker.exceptions.DockerError):
+            await container.delete(force=True)
+
+    async def cleanup_orphans(self, prefix: str) -> list[str]:
+        client = self._ensure_client()
+        containers = await client.containers.list(
+            all=True,
+            filters={"name": [prefix]},
+        )
+        removed: list[str] = []
+        for c in containers:
+            cname: str = c._container.get("Names", [""])[0].lstrip("/")
+            await self.stop(cname)
+            removed.append(cname)
+        if removed:
+            logger.info("Stopped orphaned containers", count=len(removed), names=removed)
+        return removed
+
+    async def close(self) -> None:
+        if self._client:
+            await self._client.close()
+            self._client = None
+
+    @staticmethod
+    def _spec_to_config(spec: ContainerSpec) -> dict[str, Any]:
+        """Convert a ContainerSpec to a Docker API config dict."""
+        binds = _mounts_to_binds(spec.mounts)
+        host_config: dict[str, Any] = {
+            "Binds": binds,
+        }
+
+        # AutoRemove races with wait/inspect, so we skip it and
+        # delete explicitly in the handle's stop() method.
+        if spec.memory_limit:
+            host_config["Memory"] = _parse_memory(spec.memory_limit)
+        if spec.cpu_limit:
+            host_config["NanoCpus"] = int(spec.cpu_limit * 1e9)
+        if spec.extra_hosts:
+            host_config["ExtraHosts"] = [f"{h}:{ip}" for h, ip in spec.extra_hosts.items()]
+
+        config: dict[str, Any] = {
+            "Image": spec.image,
+            "Env": [f"{k}={v}" for k, v in spec.env.items()],
+            "HostConfig": host_config,
+            "Stdin": False,
+            "AttachStdin": False,
+            "AttachStdout": False,
+            "AttachStderr": True,
+            "OpenStdin": False,
+        }
+
+        if spec.user:
+            config["User"] = spec.user
+        if spec.entrypoint:
+            config["Entrypoint"] = spec.entrypoint
+
+        return config

--- a/py/src/nanoclaw/container/runner.py
+++ b/py/src/nanoclaw/container/runner.py
@@ -72,9 +72,9 @@ def build_volume_mounts(
     is_main: bool,
     backend_config: AgentBackendConfig | None = None,
 ) -> list[VolumeMount]:
-    """Build the list of volume mounts for a container invocation.
+    """Build volume mounts for a container invocation.
 
-    This is a pure computation function (synchronous).
+    Note: creates group session directory and default settings if missing.
     """
     mounts: list[VolumeMount] = []
     project_root = PROJECT_ROOT

--- a/py/src/nanoclaw/container/runner.py
+++ b/py/src/nanoclaw/container/runner.py
@@ -1,87 +1,60 @@
-"""Container spawning with NATS-based IPC.
+"""Container specification helpers.
 
-Spawns agent execution in containers. All communication between the
-Orchestrator and Agent happens over NATS (KV + JetStream + request-reply).
+Pure functions for building volume mounts, container specs, and NATS KV
+snapshots.  Orchestration logic has moved to agent/container_executor.py.
 """
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import json
 import os
-import re
 import shutil
-import time
-import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from nanoclaw.container.runtime import (
     CONTAINER_HOST_GATEWAY,
-    CONTAINER_RUNTIME_BIN,
-    host_gateway_args,
-    readonly_mount_args,
-    stop_container,
+    ContainerSpec,
+    VolumeMount,
+    get_host_gateway_extra_hosts,
 )
 from nanoclaw.core.config import (
     CONTAINER_IMAGE,
-    CONTAINER_MAX_OUTPUT_SIZE,
-    CONTAINER_TIMEOUT,
     CREDENTIAL_PROXY_PORT,
-    DATA_DIR,
     GROUPS_DIR,
-    IDLE_TIMEOUT,
     NATS_URL,
     PROJECT_ROOT,
     TIMEZONE,
 )
 from nanoclaw.core.group_folder import resolve_group_folder_path
 from nanoclaw.core.logger import get_logger
-from nanoclaw.ipc.protocol import AgentInitData
 from nanoclaw.security.credential_proxy import detect_auth_mode
 from nanoclaw.security.mount_security import validate_additional_mounts
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
+    from nanoclaw.agent.executor import AgentBackendConfig
     from nanoclaw.core.types import RegisteredGroup
     from nanoclaw.ipc.nats_transport import NatsTransport
 
+# Backward-compat aliases
+from nanoclaw.agent.executor import AgentInput as ContainerInput
+from nanoclaw.agent.executor import AgentOutput as ContainerOutput
+
 logger = get_logger()
 
-
-@dataclass
-class ContainerInput:
-    """Input payload for the container agent."""
-
-    prompt: str
-    group_folder: str
-    chat_jid: str
-    is_main: bool
-    session_id: str | None = None
-    is_scheduled_task: bool = False
-    assistant_name: str | None = None
-
-
-@dataclass
-class ContainerOutput:
-    """Parsed output from the container agent."""
-
-    status: Literal["success", "error"]
-    result: str | None
-    new_session_id: str | None = None
-    error: str | None = None
-
-
-@dataclass(frozen=True)
-class VolumeMount:
-    """A bind mount specification for container execution."""
-
-    host_path: str
-    container_path: str
-    readonly: bool
+# Re-export VolumeMount from runtime (it used to live here)
+__all__ = [
+    "AvailableGroup",
+    "ContainerInput",
+    "ContainerOutput",
+    "ContainerSpec",
+    "VolumeMount",
+    "build_container_spec",
+    "build_volume_mounts",
+    "write_groups_snapshot",
+    "write_tasks_snapshot",
+]
 
 
 @dataclass(frozen=True)
@@ -94,22 +67,10 @@ class AvailableGroup:
     is_registered: bool
 
 
-def _parse_container_output(raw: dict[str, object]) -> ContainerOutput:
-    """Parse a raw JSON dict into a ContainerOutput, handling camelCase keys."""
-    result_val = raw.get("result")
-    new_sid = raw.get("newSessionId")
-    err_val = raw.get("error")
-    return ContainerOutput(
-        status=str(raw.get("status", "error")),  # type: ignore[arg-type]
-        result=str(result_val) if result_val is not None else None,
-        new_session_id=str(new_sid) if new_sid is not None else None,
-        error=str(err_val) if err_val is not None else None,
-    )
-
-
 def build_volume_mounts(
     group: RegisteredGroup,
     is_main: bool,
+    backend_config: AgentBackendConfig | None = None,
 ) -> list[VolumeMount]:
     """Build the list of volume mounts for a container invocation.
 
@@ -120,8 +81,6 @@ def build_volume_mounts(
     group_dir = resolve_group_folder_path(group.folder)
 
     if is_main:
-        # Main gets the project root read-only. Writable paths the agent needs
-        # (group folder, .claude/) are mounted separately below.
         mounts.append(
             VolumeMount(
                 host_path=str(project_root),
@@ -130,7 +89,7 @@ def build_volume_mounts(
             )
         )
 
-        # Shadow .env so the agent cannot read secrets from the mounted project root.
+        # Shadow .env so the agent cannot read secrets
         env_file = project_root / ".env"
         if env_file.exists():
             mounts.append(
@@ -141,7 +100,6 @@ def build_volume_mounts(
                 )
             )
 
-        # Main also gets its group folder as the working directory
         mounts.append(
             VolumeMount(
                 host_path=str(group_dir),
@@ -150,7 +108,6 @@ def build_volume_mounts(
             )
         )
     else:
-        # Other groups only get their own folder
         mounts.append(
             VolumeMount(
                 host_path=str(group_dir),
@@ -159,7 +116,6 @@ def build_volume_mounts(
             )
         )
 
-        # Global memory directory (read-only for non-main)
         global_dir = GROUPS_DIR / "global"
         if global_dir.exists():
             mounts.append(
@@ -170,7 +126,9 @@ def build_volume_mounts(
                 )
             )
 
-    # Per-group Claude sessions directory (isolated from other groups)
+    # Per-group Claude sessions directory
+    from nanoclaw.core.config import DATA_DIR
+
     group_sessions_dir = DATA_DIR / "sessions" / group.folder / ".claude"
     group_sessions_dir.mkdir(parents=True, exist_ok=True)
     settings_file = group_sessions_dir / "settings.json"
@@ -208,9 +166,7 @@ def build_volume_mounts(
         )
     )
 
-    # No IPC directory mount needed — all communication goes through NATS.
-
-    # Additional mounts validated against external allowlist (tamper-proof from containers)
+    # Additional mounts validated against external allowlist
     if group.container_config and group.container_config.additional_mounts:
         validated_mounts = validate_additional_mounts(
             group.container_config.additional_mounts,
@@ -226,407 +182,60 @@ def build_volume_mounts(
                 )
             )
 
+    # Apply backend config adjustments
+    if backend_config:
+        if backend_config.skip_claude_session:
+            mounts = [m for m in mounts if ".claude" not in m.container_path]
+        for host, container, ro in backend_config.extra_mounts:
+            mounts.append(VolumeMount(host_path=host, container_path=container, readonly=ro))
+
     return mounts
 
 
-def build_container_args(
+def build_container_spec(
     mounts: list[VolumeMount],
     container_name: str,
     job_id: str,
-) -> list[str]:
-    """Build the CLI arguments for the container runtime.
-
-    This is a pure computation function (synchronous).
-    """
-    args: list[str] = ["run", "-i", "--rm", "--name", container_name]
-
-    # Pass host timezone so container's local time matches the user's
-    args.extend(["-e", f"TZ={TIMEZONE}"])
-
-    # NATS connection for IPC
+    backend_config: AgentBackendConfig | None = None,
+) -> ContainerSpec:
+    """Build a ContainerSpec from mounts and config. Replaces build_container_args()."""
+    image = backend_config.image if backend_config else CONTAINER_IMAGE
     nats_url = NATS_URL.replace("localhost", CONTAINER_HOST_GATEWAY)
-    args.extend(["-e", f"NATS_URL={nats_url}"])
-    args.extend(["-e", f"JOB_ID={job_id}"])
 
-    # Route API traffic through the credential proxy (containers never see real secrets)
-    args.extend(
-        [
-            "-e",
-            f"ANTHROPIC_BASE_URL=http://{CONTAINER_HOST_GATEWAY}:{CREDENTIAL_PROXY_PORT}",
-        ]
-    )
+    env: dict[str, str] = {
+        "TZ": TIMEZONE,
+        "NATS_URL": nats_url,
+        "JOB_ID": job_id,
+        "ANTHROPIC_BASE_URL": f"http://{CONTAINER_HOST_GATEWAY}:{CREDENTIAL_PROXY_PORT}",
+    }
 
     # Mirror the host's auth method with a placeholder value.
     auth_mode = detect_auth_mode()
     if auth_mode == "api-key":
-        args.extend(["-e", "ANTHROPIC_API_KEY=placeholder"])
+        env["ANTHROPIC_API_KEY"] = "placeholder"
     else:
-        args.extend(["-e", "CLAUDE_CODE_OAUTH_TOKEN=placeholder"])
+        env["CLAUDE_CODE_OAUTH_TOKEN"] = "placeholder"
 
-    # Runtime-specific args for host gateway resolution
-    args.extend(host_gateway_args())
+    if backend_config:
+        env.update(backend_config.extra_env)
 
     # Run as host user so bind-mounted files are accessible.
-    host_uid: int | None = None
-    host_gid: int | None = None
+    user: str | None = None
     if hasattr(os, "getuid"):
         host_uid = os.getuid()
-    if hasattr(os, "getgid"):
-        host_gid = os.getgid()
-    if host_uid is not None and host_uid != 0 and host_uid != 1000:
-        args.extend(["--user", f"{host_uid}:{host_gid}"])
-        args.extend(["-e", "HOME=/home/agent"])
+        host_gid = os.getgid() if hasattr(os, "getgid") else host_uid
+        if host_uid != 0 and host_uid != 1000:
+            user = f"{host_uid}:{host_gid}"
+            env["HOME"] = "/home/agent"
 
-    for mount in mounts:
-        if mount.readonly:
-            args.extend(readonly_mount_args(mount.host_path, mount.container_path))
-        else:
-            args.extend(["-v", f"{mount.host_path}:{mount.container_path}"])
-
-    args.append(CONTAINER_IMAGE)
-
-    return args
-
-
-async def run_container_agent(
-    group: RegisteredGroup,
-    inp: ContainerInput,
-    on_process: Callable[[asyncio.subprocess.Process, str, str], None],
-    on_output: Callable[[ContainerOutput], Awaitable[None]] | None = None,
-    transport: NatsTransport | None = None,
-) -> ContainerOutput:
-    """Run the agent inside a container with NATS-based IPC.
-
-    Channel 1: Writes initial input to KV before starting container.
-    Channel 2: Subscribes to JetStream for streaming results.
-    Channel 6: Writes snapshots to KV before starting container.
-    Stderr is still read for logging purposes.
-    """
-    start_time = time.monotonic()
-    start_epoch_ms = int(time.time() * 1000)
-
-    group_dir = resolve_group_folder_path(group.folder)
-    group_dir.mkdir(parents=True, exist_ok=True)
-
-    job_id = f"{group.folder}-{uuid.uuid4().hex[:12]}"
-
-    mounts = build_volume_mounts(group, inp.is_main)
-    safe_name = re.sub(r"[^a-zA-Z0-9-]", "-", group.folder)
-    container_name = f"nanoclaw-{safe_name}-{start_epoch_ms}"
-    container_args = build_container_args(mounts, container_name, job_id)
-
-    logger.debug(
-        "Container mount configuration",
-        group=group.name,
-        container_name=container_name,
-        job_id=job_id,
-        mounts=[f"{m.host_path} -> {m.container_path}{' (ro)' if m.readonly else ''}" for m in mounts],
-        container_args=" ".join(container_args),
-    )
-
-    logger.info(
-        "Spawning container agent",
-        group=group.name,
-        container_name=container_name,
-        job_id=job_id,
-        mount_count=len(mounts),
-        is_main=inp.is_main,
-    )
-
-    logs_dir = group_dir / "logs"
-    logs_dir.mkdir(parents=True, exist_ok=True)
-
-    # Channel 1: Write initial input to KV before starting container
-    if transport is not None:
-        kv_init = await transport.js.key_value("agent-init")
-        agent_init = AgentInitData(
-            prompt=inp.prompt,
-            group_folder=inp.group_folder,
-            chat_jid=inp.chat_jid,
-            is_main=inp.is_main,
-            session_id=inp.session_id,
-            is_scheduled_task=inp.is_scheduled_task,
-            assistant_name=inp.assistant_name,
-        )
-        await kv_init.put(job_id, agent_init.serialize())
-
-    proc = await asyncio.create_subprocess_exec(
-        CONTAINER_RUNTIME_BIN,
-        *container_args,
-        stdin=asyncio.subprocess.DEVNULL,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.PIPE,
-    )
-
-    # callback function to register container into GroupQueue
-    on_process(proc, container_name, job_id)
-
-    stderr_buf = ""
-    stderr_truncated = False
-
-    # Streaming output state
-    new_session_id: str | None = None
-    had_streaming_output = False
-    timed_out = False
-
-    config_timeout = (
-        group.container_config.timeout if group.container_config else CONTAINER_TIMEOUT
-    ) or CONTAINER_TIMEOUT
-    timeout_ms = max(config_timeout, IDLE_TIMEOUT + 30_000)
-    timeout_s = timeout_ms / 1000.0
-
-    # Timeout management via an asyncio.Event and a watcher task
-    activity_event = asyncio.Event()
-
-    async def _timeout_watcher() -> None:
-        nonlocal timed_out
-        while True:
-            activity_event.clear()
-            try:
-                await asyncio.wait_for(activity_event.wait(), timeout=timeout_s)
-            except TimeoutError:
-                timed_out = True
-                logger.error(
-                    "Container timeout, stopping gracefully",
-                    group=group.name,
-                    container_name=container_name,
-                )
-                try:
-                    stop_proc = await asyncio.create_subprocess_exec(
-                        *stop_container(container_name).split(),
-                        stdout=asyncio.subprocess.DEVNULL,
-                        stderr=asyncio.subprocess.DEVNULL,
-                    )
-                    try:
-                        await asyncio.wait_for(stop_proc.wait(), timeout=15.0)
-                    except TimeoutError:
-                        logger.warning(
-                            "Graceful stop failed, force killing",
-                            group=group.name,
-                            container_name=container_name,
-                        )
-                        proc.kill()
-                except OSError:
-                    proc.kill()
-                return
-
-    timeout_task = asyncio.create_task(_timeout_watcher()) # why asycn?
-
-    # Channel 2: Subscribe to JetStream for streaming results
-    results_sub = None
-    if transport is not None and on_output is not None:
-        results_sub = await transport.js.subscribe(f"agent.{job_id}.results")
-
-    async def _read_results() -> None:
-        nonlocal new_session_id, had_streaming_output
-        if results_sub is None:
-            return
-        async for msg in results_sub.messages:
-            try:
-                raw = json.loads(msg.data)
-                parsed = _parse_container_output(raw)
-                if parsed.new_session_id:
-                    new_session_id = parsed.new_session_id
-                had_streaming_output = True
-                activity_event.set()
-                if on_output is not None:
-                    await on_output(parsed)
-                await msg.ack()
-            except (json.JSONDecodeError, KeyError, TypeError) as err:
-                logger.warning(
-                    "Failed to parse streamed output",
-                    group=group.name,
-                    error=str(err),
-                )
-                await msg.ack()
-
-    async def _read_stderr() -> None:
-        nonlocal stderr_buf, stderr_truncated
-        assert proc.stderr is not None
-        while True:
-            chunk_bytes = await proc.stderr.read(8192)
-            if not chunk_bytes:
-                break
-            chunk = chunk_bytes.decode("utf-8", errors="replace")
-            lines = chunk.strip().split("\n")
-            for line in lines:
-                if line:
-                    logger.debug(line, container=group.folder)
-            if stderr_truncated:
-                continue
-            remaining = CONTAINER_MAX_OUTPUT_SIZE - len(stderr_buf)
-            if len(chunk) > remaining:
-                stderr_buf += chunk[:remaining]
-                stderr_truncated = True
-                logger.warning(
-                    "Container stderr truncated due to size limit",
-                    group=group.name,
-                    size=len(stderr_buf),
-                )
-            else:
-                stderr_buf += chunk
-
-    # Run readers concurrently
-    tasks: list[asyncio.Task[None]] = [asyncio.create_task(_read_stderr())]
-    if results_sub is not None:
-        tasks.append(asyncio.create_task(_read_results()))
-
-    # Wait for process to exit
-    code = await proc.wait()
-
-    # Cancel the results subscription and readers
-    if results_sub is not None:
-        await results_sub.unsubscribe()
-    for t in tasks:
-        t.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await t
-
-    # Cancel the timeout watcher
-    timeout_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await timeout_task
-
-    duration_ms = int((time.monotonic() - start_time) * 1000)
-
-    if timed_out:
-        ts = datetime.now(UTC).isoformat().replace(":", "-").replace(".", "-")
-        timeout_log = logs_dir / f"container-{ts}.log"
-        timeout_log.write_text(
-            "\n".join(
-                [
-                    "=== Container Run Log (TIMEOUT) ===",
-                    f"Timestamp: {datetime.now(UTC).isoformat()}",
-                    f"Group: {group.name}",
-                    f"Container: {container_name}",
-                    f"Job ID: {job_id}",
-                    f"Duration: {duration_ms}ms",
-                    f"Exit Code: {code}",
-                    f"Had Streaming Output: {had_streaming_output}",
-                ]
-            ),
-            encoding="utf-8",
-        )
-
-        if had_streaming_output:
-            logger.info(
-                "Container timed out after output (idle cleanup)",
-                group=group.name,
-                container_name=container_name,
-                duration=duration_ms,
-                code=code,
-            )
-            return ContainerOutput(
-                status="success",
-                result=None,
-                new_session_id=new_session_id,
-            )
-
-        logger.error(
-            "Container timed out with no output",
-            group=group.name,
-            container_name=container_name,
-            duration=duration_ms,
-            code=code,
-        )
-        return ContainerOutput(
-            status="error",
-            result=None,
-            error=f"Container timed out after {config_timeout}ms",
-        )
-
-    timestamp = datetime.now(UTC).isoformat().replace(":", "-").replace(".", "-")
-    log_file = logs_dir / f"container-{timestamp}.log"
-    is_verbose = os.environ.get("LOG_LEVEL") in ("debug", "trace")
-
-    log_lines: list[str] = [
-        "=== Container Run Log ===",
-        f"Timestamp: {datetime.now(UTC).isoformat()}",
-        f"Group: {group.name}",
-        f"IsMain: {inp.is_main}",
-        f"Job ID: {job_id}",
-        f"Duration: {duration_ms}ms",
-        f"Exit Code: {code}",
-        f"Stderr Truncated: {stderr_truncated}",
-        "",
-    ]
-
-    is_error = code != 0
-
-    if is_verbose or is_error:
-        if is_verbose:
-            log_lines.extend(
-                [
-                    "=== Input Summary ===",
-                    f"Prompt length: {len(inp.prompt)} chars",
-                    f"Session ID: {inp.session_id or 'new'}",
-                    f"Job ID: {job_id}",
-                    "",
-                ]
-            )
-        else:
-            log_lines.extend(
-                [
-                    "=== Input Summary ===",
-                    f"Prompt length: {len(inp.prompt)} chars",
-                    f"Session ID: {inp.session_id or 'new'}",
-                    "",
-                ]
-            )
-        log_lines.extend(
-            [
-                "=== Container Args ===",
-                " ".join(container_args),
-                "",
-                "=== Mounts ===",
-                "\n".join(f"{m.host_path} -> {m.container_path}{' (ro)' if m.readonly else ''}" for m in mounts),
-                "",
-                f"=== Stderr{' (TRUNCATED)' if stderr_truncated else ''} ===",
-                stderr_buf,
-            ]
-        )
-    else:
-        log_lines.extend(
-            [
-                "=== Input Summary ===",
-                f"Prompt length: {len(inp.prompt)} chars",
-                f"Session ID: {inp.session_id or 'new'}",
-                "",
-                "=== Mounts ===",
-                "\n".join(f"{m.container_path}{' (ro)' if m.readonly else ''}" for m in mounts),
-                "",
-            ]
-        )
-
-    log_file.write_text("\n".join(log_lines), encoding="utf-8")
-    logger.debug("Container log written", log_file=str(log_file), verbose=is_verbose)
-
-    if code != 0:
-        logger.error(
-            "Container exited with error",
-            group=group.name,
-            code=code,
-            duration=duration_ms,
-            stderr=stderr_buf,
-            log_file=str(log_file),
-        )
-        return ContainerOutput(
-            status="error",
-            result=None,
-            error=f"Container exited with code {code}: {stderr_buf[-200:]}",
-        )
-
-    # Streaming mode: return completion marker
-    logger.info(
-        "Container completed",
-        group=group.name,
-        duration=duration_ms,
-        new_session_id=new_session_id,
-    )
-    return ContainerOutput(
-        status="success",
-        result=None,
-        new_session_id=new_session_id,
+    return ContainerSpec(
+        name=container_name,
+        image=image,
+        mounts=mounts,
+        env=env,
+        user=user,
+        extra_hosts=get_host_gateway_extra_hosts(),
+        entrypoint=backend_config.entrypoint if backend_config else None,
     )
 
 

--- a/py/src/nanoclaw/container/runtime.py
+++ b/py/src/nanoclaw/container/runtime.py
@@ -1,34 +1,127 @@
-"""Container runtime abstraction (Docker).
+"""Container runtime abstraction.
 
-All runtime-specific logic lives here so swapping runtimes means changing one file.
+Defines the ContainerRuntime Protocol and supporting types (ContainerSpec,
+ContainerHandle, VolumeMount).  Concrete implementations live in separate
+modules (e.g. docker_runtime.py).
+
+Platform helpers for proxy bind-host and host-gateway detection are kept as
+module-level functions so they can be used regardless of runtime.
 """
 
 from __future__ import annotations
 
-import contextlib
 import os
 import platform
-import subprocess
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
 
 from nanoclaw.core.logger import get_logger
 
 logger = get_logger()
 
-CONTAINER_RUNTIME_BIN: str = "docker"
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VolumeMount:
+    """A bind mount specification for container execution."""
+
+    host_path: str
+    container_path: str
+    readonly: bool
+
+
+@dataclass(frozen=True)
+class ContainerSpec:
+    """Full specification for running a container."""
+
+    name: str
+    image: str
+    mounts: list[VolumeMount] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    user: str | None = None  # "uid:gid"
+    memory_limit: str | None = None  # "512m"
+    cpu_limit: float | None = None  # 1.0
+    extra_hosts: dict[str, str] = field(default_factory=dict)
+    remove_on_exit: bool = True
+    entrypoint: list[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Protocols
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ContainerHandle(Protocol):
+    """Handle to a running container."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def pid(self) -> int:
+        """Process ID (or container ID hash) for tracking."""
+        ...
+
+    async def wait(self) -> int:
+        """Wait for exit, return exit code."""
+        ...
+
+    async def stop(self, timeout: int = 1) -> None:
+        """Stop the container."""
+        ...
+
+    def read_stderr(self) -> AsyncIterator[bytes]:
+        """Stream stderr for logging."""
+        ...
+
+
+class ContainerRuntime(Protocol):
+    """Protocol for container execution backends."""
+
+    @property
+    def name(self) -> str: ...
+
+    async def ensure_available(self) -> None: ...
+
+    async def run(self, spec: ContainerSpec) -> ContainerHandle: ...
+
+    async def stop(self, name: str, timeout: int = 1) -> None: ...
+
+    async def cleanup_orphans(self, prefix: str) -> list[str]: ...
+
+    async def close(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
 CONTAINER_HOST_GATEWAY: str = "host.docker.internal"
+
+
+# ---------------------------------------------------------------------------
+# Platform helpers
+# ---------------------------------------------------------------------------
 
 
 def _detect_proxy_bind_host() -> str:
     """Detect the appropriate bind host for the credential proxy.
 
-    Docker Desktop (macOS): 127.0.0.1 — the VM routes host.docker.internal to loopback.
+    Docker Desktop (macOS): 127.0.0.1 -- the VM routes host.docker.internal to loopback.
     Docker (Linux): bind to the docker0 bridge IP so only containers can reach it.
     """
     if platform.system() == "Darwin":
         return "127.0.0.1"
 
-    # WSL uses Docker Desktop — loopback is correct
+    # WSL uses Docker Desktop -- loopback is correct
     if Path("/proc/sys/fs/binfmt_misc/WSLInterop").exists():
         return "127.0.0.1"
 
@@ -55,62 +148,37 @@ def _detect_proxy_bind_host() -> str:
 PROXY_BIND_HOST: str = os.environ.get("CREDENTIAL_PROXY_HOST") or _detect_proxy_bind_host()
 
 
-def host_gateway_args() -> list[str]:
-    """CLI args needed for the container to resolve the host gateway."""
+def detect_proxy_bind_host() -> str:
+    """Public API for proxy bind host detection."""
+    return PROXY_BIND_HOST
+
+
+def get_host_gateway_extra_hosts() -> dict[str, str]:
+    """Extra hosts needed for containers to resolve the host gateway."""
     if platform.system() == "Linux":
-        return ["--add-host=host.docker.internal:host-gateway"]
-    return []
+        return {"host.docker.internal": "host-gateway"}
+    return {}
 
 
-def readonly_mount_args(host_path: str, container_path: str) -> list[str]:
-    """Returns CLI args for a readonly bind mount."""
-    return ["-v", f"{host_path}:{container_path}:ro"]
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
 
 
-def stop_container(name: str) -> str:
-    """Returns the shell command to stop a container by name."""
-    return f"{CONTAINER_RUNTIME_BIN} stop -t 1 {name}"
+def get_runtime(runtime_name: str | None = None) -> ContainerRuntime:
+    """Create a ContainerRuntime from name (defaults to CONTAINER_RUNTIME env var)."""
+    from nanoclaw.core.config import CONTAINER_RUNTIME
 
+    name = runtime_name or CONTAINER_RUNTIME
 
-def ensure_container_runtime_running() -> None:
-    """Ensure the container runtime is running."""
-    try:
-        subprocess.run(
-            [CONTAINER_RUNTIME_BIN, "info"],
-            capture_output=True,
-            timeout=10,
-            check=True,
-        )
-        logger.debug("Container runtime already running")
-    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as exc:
-        logger.error("Failed to reach container runtime", error=str(exc))
-        msg = (
-            "\n╔════════════════════════════════════════════════════════════════╗\n"
-            "║  FATAL: Container runtime failed to start                      ║\n"
-            "║                                                                ║\n"
-            "║  Agents cannot run without a container runtime. To fix:        ║\n"
-            "║  1. Ensure Docker is installed and running                     ║\n"
-            "║  2. Run: docker info                                           ║\n"
-            "║  3. Restart NanoClaw                                           ║\n"
-            "╚════════════════════════════════════════════════════════════════╝\n"
-        )
-        raise RuntimeError(msg) from exc
+    if name == "docker":
+        from nanoclaw.container.docker_runtime import DockerRuntime
 
+        return DockerRuntime()
 
-def cleanup_orphans() -> None:
-    """Kill orphaned NanoClaw containers from previous runs."""
-    try:
-        result = subprocess.run(
-            [CONTAINER_RUNTIME_BIN, "ps", "--filter", "name=nanoclaw-", "--format", "{{.Names}}"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        orphans = [name for name in result.stdout.strip().splitlines() if name]
-        for name in orphans:
-            with contextlib.suppress(OSError):
-                subprocess.run(stop_container(name).split(), capture_output=True, check=False)
-        if orphans:
-            logger.info("Stopped orphaned containers", count=len(orphans), names=orphans)
-    except OSError as exc:
-        logger.warning("Failed to clean up orphaned containers", error=str(exc))
+    if name == "k8s":
+        msg = "Kubernetes runtime is not yet implemented"
+        raise NotImplementedError(msg)
+
+    msg = f"Unknown container runtime: {name}"
+    raise ValueError(msg)

--- a/py/src/nanoclaw/container/scheduler.py
+++ b/py/src/nanoclaw/container/scheduler.py
@@ -17,6 +17,7 @@ from nanoclaw.core.logger import get_logger
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from nanoclaw.container.runtime import ContainerHandle, ContainerRuntime
     from nanoclaw.ipc.nats_transport import NatsTransport
 
 from nanoclaw.core.config import MAX_CONCURRENT_CONTAINERS
@@ -42,7 +43,7 @@ class _GroupState:
     running_task_id: str | None = None
     pending_messages: bool = False
     pending_tasks: list[_QueuedTask] = field(default_factory=list)
-    process: object | None = None  # asyncio.subprocess.Process
+    process: ContainerHandle | None = None
     container_name: str | None = None
     group_folder: str | None = None
     job_id: str | None = None
@@ -52,7 +53,11 @@ class _GroupState:
 class GroupQueue:
     """Manages per-group container concurrency and task/message queuing."""
 
-    def __init__(self, transport: NatsTransport | None = None) -> None:
+    def __init__(
+        self,
+        transport: NatsTransport | None = None,
+        runtime: ContainerRuntime | None = None,
+    ) -> None:
         self._groups: dict[str, _GroupState] = {}
         self._active_count: int = 0
         self._waiting_groups: list[str] = []
@@ -60,6 +65,7 @@ class GroupQueue:
         self._shutting_down: bool = False
         self._background_tasks: set[asyncio.Task[None]] = set()
         self._transport = transport
+        self._runtime = runtime
 
     def _spawn(self, coro: Awaitable[None]) -> None:
         """Launch a background task and track it to prevent GC."""
@@ -144,12 +150,12 @@ class GroupQueue:
     def register_process(
         self,
         group_jid: str,
-        proc: object,
+        proc: ContainerHandle,
         container_name: str,
         group_folder: str | None = None,
         job_id: str | None = None,
     ) -> None:
-        """Track an active container process for a group."""
+        """Track an active container handle for a group."""
         state = self._get_group(group_jid)
         state.process = proc
         state.container_name = container_name
@@ -353,3 +359,11 @@ class GroupQueue:
             active_count=self._active_count,
             detached_containers=active_containers,
         )
+
+        # Stop active containers via runtime if available
+        if self._runtime:
+            for name in active_containers:
+                try:
+                    await self._runtime.stop(name)
+                except (OSError, RuntimeError):
+                    logger.debug("Failed to stop container during shutdown", container=name)

--- a/py/src/nanoclaw/core/config.py
+++ b/py/src/nanoclaw/core/config.py
@@ -35,6 +35,7 @@ CONTAINER_MAX_OUTPUT_SIZE: int = int(os.environ.get("CONTAINER_MAX_OUTPUT_SIZE",
 CREDENTIAL_PROXY_PORT: int = int(os.environ.get("CREDENTIAL_PROXY_PORT", "3001"))
 IDLE_TIMEOUT: int = int(os.environ.get("IDLE_TIMEOUT", "1800000"))  # 30 min
 MAX_CONCURRENT_CONTAINERS: int = max(1, int(os.environ.get("MAX_CONCURRENT_CONTAINERS", "5")))
+CONTAINER_RUNTIME: str = os.environ.get("CONTAINER_RUNTIME", "docker")
 
 TRIGGER_PATTERN: re.Pattern[str] = re.compile(
     rf"^@{re.escape(ASSISTANT_NAME)}\b",

--- a/py/src/nanoclaw/ipc/protocol.py
+++ b/py/src/nanoclaw/ipc/protocol.py
@@ -20,6 +20,8 @@ class AgentInitData:
     session_id: str | None = None
     is_scheduled_task: bool = False
     assistant_name: str | None = None
+    system_prompt: str | None = None
+    role_config: dict[str, object] | None = None
 
     def serialize(self) -> bytes:
         return json.dumps(asdict(self)).encode()
@@ -35,4 +37,6 @@ class AgentInitData:
             session_id=raw.get("session_id"),
             is_scheduled_task=raw.get("is_scheduled_task", False),
             assistant_name=raw.get("assistant_name"),
+            system_prompt=raw.get("system_prompt"),
+            role_config=raw.get("role_config"),
         )

--- a/py/src/nanoclaw/main.py
+++ b/py/src/nanoclaw/main.py
@@ -12,17 +12,17 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+from nanoclaw.agent import CLAUDE_CODE_BACKEND, AgentInput, AgentOutput
+from nanoclaw.agent.container_executor import ContainerAgentExecutor
 from nanoclaw.container.runner import (
-    ContainerInput,
-    ContainerOutput,
-    run_container_agent,
+    AvailableGroup,
     write_groups_snapshot,
     write_tasks_snapshot,
 )
 from nanoclaw.container.runtime import (
     PROXY_BIND_HOST,
-    cleanup_orphans,
-    ensure_container_runtime_running,
+    ContainerHandle,
+    get_runtime,
 )
 from nanoclaw.container.scheduler import GroupQueue
 from nanoclaw.core.config import (
@@ -69,7 +69,7 @@ from nanoclaw.security.sender_allowlist import (
 )
 
 if TYPE_CHECKING:
-    from nanoclaw.container.runner import AvailableGroup
+    from nanoclaw.container.runtime import ContainerRuntime
     from nanoclaw.core.types import Channel, NewMessage, RegisteredGroup
 
 logger = get_logger()
@@ -90,6 +90,8 @@ _message_loop_running: bool = False
 _channels: list[Channel] = []
 _queue: GroupQueue = GroupQueue()
 _transport: NatsTransport | None = None
+_runtime: ContainerRuntime | None = None
+_executor: ContainerAgentExecutor | None = None
 _bg_tasks: set[asyncio.Task[None]] = set()
 
 
@@ -142,12 +144,7 @@ def _register_group(jid: str, group: RegisteredGroup) -> None:
 
 
 def get_available_groups() -> list[AvailableGroup]:
-    """Get available groups list for the agent.
-
-    Returns groups ordered by most recent activity.
-    """
-    from nanoclaw.container.runner import AvailableGroup
-
+    """Get available groups list for the agent."""
     chats = get_all_chats()
     registered_jids = set(_registered_groups.keys())
 
@@ -175,15 +172,9 @@ def _set_registered_groups(groups: dict[str, RegisteredGroup]) -> None:
 
 
 async def _start_nats_ipc_subscriptions(transport: NatsTransport, deps: _IpcDepsImpl) -> list[asyncio.Task[None]]:
-    """Subscribe to NATS subjects for agent IPC messages and tasks.
-
-    Replaces the file-based IPC watcher (start_ipc_watcher).
-    Returns background tasks that should be cancelled on shutdown.
-    """
+    """Subscribe to NATS subjects for agent IPC messages and tasks."""
     tasks: list[asyncio.Task[None]] = []
 
-    # Subscribe to agent messages (Channel 4: agent -> user)
-    # Durable consumer so NATS remembers our position across restarts.
     messages_sub = await transport.js.subscribe("agent.*.messages", durable="orch-messages")
 
     async def _handle_messages() -> None:
@@ -194,9 +185,7 @@ async def _start_nats_ipc_subscriptions(transport: NatsTransport, deps: _IpcDeps
                     chat_jid = data["chatJid"]
                     source_group = data.get("groupFolder", "")
 
-                    # Authorization
                     registered_groups = deps.registered_groups()
-                    # Determine if source is main
                     folder_is_main: dict[str, bool] = {}
                     for group in registered_groups.values():
                         if group.is_main:
@@ -220,7 +209,6 @@ async def _start_nats_ipc_subscriptions(transport: NatsTransport, deps: _IpcDeps
 
     tasks.append(asyncio.create_task(_handle_messages()))
 
-    # Subscribe to agent tasks (Channel 5: agent -> orch)
     tasks_sub = await transport.js.subscribe("agent.*.tasks", durable="orch-tasks")
 
     async def _handle_tasks() -> None:
@@ -229,7 +217,6 @@ async def _start_nats_ipc_subscriptions(transport: NatsTransport, deps: _IpcDeps
                 data = json.loads(msg.data)
                 source_group = data.get("groupFolder", data.get("createdBy", ""))
 
-                # Determine is_main
                 registered_groups = deps.registered_groups()
                 folder_is_main: dict[str, bool] = {}
                 for group in registered_groups.values():
@@ -255,11 +242,7 @@ async def _start_nats_ipc_subscriptions(transport: NatsTransport, deps: _IpcDeps
 
 
 async def _process_group_messages(chat_jid: str) -> bool:
-    """Process all pending messages for a group.
-
-    Called by the GroupQueue when it's this group's turn.
-    Returns True on success, False to signal retry.
-    """
+    """Process all pending messages for a group."""
     global _last_agent_timestamp
 
     group = _registered_groups.get(chat_jid)
@@ -279,7 +262,6 @@ async def _process_group_messages(chat_jid: str) -> bool:
     if not missed_messages:
         return True
 
-    # For non-main groups, check if trigger is required and present
     if not is_main_group and group.requires_trigger is not False:
         allowlist_cfg = load_sender_allowlist()
         has_trigger = any(
@@ -292,14 +274,12 @@ async def _process_group_messages(chat_jid: str) -> bool:
 
     prompt = format_messages(missed_messages, TIMEZONE)
 
-    # Advance cursor; save old cursor for rollback on error
     previous_cursor = _last_agent_timestamp.get(chat_jid, "")
     _last_agent_timestamp[chat_jid] = missed_messages[-1].timestamp
     _save_state()
 
     logger.info("Processing messages", group=group.name, message_count=len(missed_messages))
 
-    # Track idle timer for closing stdin when agent is idle
     idle_handle: asyncio.TimerHandle | None = None
 
     def _reset_idle_timer() -> None:
@@ -312,7 +292,6 @@ async def _process_group_messages(chat_jid: str) -> bool:
             lambda: _queue.close_stdin(chat_jid),
         )
 
-    # Set typing indicator
     if hasattr(channel, "set_typing"):
         try:
             await channel.set_typing(chat_jid, True)
@@ -322,11 +301,10 @@ async def _process_group_messages(chat_jid: str) -> bool:
     had_error = False
     output_sent_to_user = False
 
-    async def _on_output(result: ContainerOutput) -> None:
+    async def _on_output(result: AgentOutput) -> None:
         nonlocal had_error, output_sent_to_user
         if result.result:
             raw = result.result
-            # Strip <internal>...</internal> blocks
             import re
 
             text = re.sub(r"<internal>[\s\S]*?</internal>", "", raw).strip()
@@ -334,7 +312,6 @@ async def _process_group_messages(chat_jid: str) -> bool:
             if text:
                 await channel.send_message(chat_jid, text)
                 output_sent_to_user = True
-            # Only reset idle timer on actual results
             _reset_idle_timer()
         if result.status == "success":
             _queue.notify_idle(chat_jid)
@@ -356,7 +333,6 @@ async def _process_group_messages(chat_jid: str) -> bool:
                 group=group.name,
             )
             return True
-        # Roll back cursor for retry
         _last_agent_timestamp[chat_jid] = previous_cursor
         _save_state()
         logger.warning("Agent error, rolled back message cursor for retry", group=group.name)
@@ -369,13 +345,12 @@ async def _run_agent(
     group: RegisteredGroup,
     prompt: str,
     chat_jid: str,
-    on_output: Callable[[ContainerOutput], Awaitable[None]] | None = None,
+    on_output: Callable[[AgentOutput], Awaitable[None]] | None = None,
 ) -> str:
     """Run agent in a container. Returns 'success' or 'error'."""
     is_main = group.is_main
     session_id = _sessions.get(group.folder)
 
-    # Update snapshots in NATS KV for container to read (Channel 6)
     if _transport is not None:
         tasks = get_all_tasks()
         await write_tasks_snapshot(
@@ -405,12 +380,15 @@ async def _run_agent(
             set(_registered_groups.keys()),
         )
 
-    # Wrap on_output to track session ID from streamed results
+    if _executor is None:
+        logger.error("Agent executor not initialized")
+        return "error"
+
     wrapped_on_output = None
     if on_output is not None:
         original_on_output = on_output
 
-        async def _wrapped(output: ContainerOutput) -> None:
+        async def _wrapped(output: AgentOutput) -> None:
             if output.new_session_id:
                 _sessions[group.folder] = output.new_session_id
                 set_session(group.folder, output.new_session_id)
@@ -419,9 +397,8 @@ async def _run_agent(
         wrapped_on_output = _wrapped
 
     try:
-        output = await run_container_agent(
-            group,
-            ContainerInput(
+        output = await _executor.execute(
+            AgentInput(
                 prompt=prompt,
                 session_id=session_id,
                 group_folder=group.folder,
@@ -429,11 +406,10 @@ async def _run_agent(
                 is_main=is_main,
                 assistant_name=ASSISTANT_NAME,
             ),
-            lambda proc, container_name, job_id: _queue.register_process(
-                chat_jid, proc, container_name, group.folder, job_id
+            lambda handle, container_name, job_id: _queue.register_process(
+                chat_jid, handle, container_name, group.folder, job_id
             ),
             wrapped_on_output,
-            transport=_transport,
         )
 
         if output.new_session_id:
@@ -474,11 +450,9 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
             if messages:
                 logger.info("New messages", count=len(messages))
 
-                # Advance the "seen" cursor for all messages immediately
                 _last_timestamp = new_timestamp
                 _save_state()
 
-                # Deduplicate by group
                 messages_by_group: dict[str, list[NewMessage]] = {}
                 for msg in messages:
                     messages_by_group.setdefault(msg.chat_jid, []).append(msg)
@@ -506,7 +480,6 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
                         if not has_trigger:
                             continue
 
-                    # Pull all messages since lastAgentTimestamp
                     all_pending = get_messages_since(
                         chat_jid,
                         _last_agent_timestamp.get(chat_jid, ""),
@@ -521,30 +494,25 @@ async def _message_loop(shutdown_event: asyncio.Event) -> None:
                         )
                         _last_agent_timestamp[chat_jid] = messages_to_send[-1].timestamp
                         _save_state()
-                        # Show typing indicator
                         if hasattr(channel, "set_typing"):
                             try:
                                 await channel.set_typing(chat_jid, True)
                             except (OSError, RuntimeError, TypeError, ValueError):
                                 logger.warning("Failed to set typing indicator", chat_jid=chat_jid)
                     else:
-                        # No active container - enqueue for a new one
                         _queue.enqueue_message_check(chat_jid)
         except (OSError, RuntimeError, TypeError, ValueError):
             logger.exception("Error in message loop")
 
         try:
             await asyncio.wait_for(shutdown_event.wait(), timeout=POLL_INTERVAL)
-            break  # shutdown_event was set
+            break
         except TimeoutError:
             pass
 
 
 def _recover_pending_messages() -> None:
-    """Startup recovery: check for unprocessed messages in registered groups.
-
-    Handles crash between advancing lastTimestamp and processing messages.
-    """
+    """Startup recovery: check for unprocessed messages in registered groups."""
     for chat_jid, group in _registered_groups.items():
         since_timestamp = _last_agent_timestamp.get(chat_jid, "")
         pending = get_messages_since(chat_jid, since_timestamp, ASSISTANT_NAME)
@@ -553,10 +521,12 @@ def _recover_pending_messages() -> None:
             _queue.enqueue_message_check(chat_jid)
 
 
-def _ensure_container_system_running() -> None:
+async def _ensure_container_system_running() -> None:
     """Ensure the container runtime is running and clean up orphans."""
-    ensure_container_runtime_running()
-    cleanup_orphans()
+    global _runtime
+    _runtime = get_runtime()
+    await _runtime.ensure_available()
+    await _runtime.cleanup_orphans("nanoclaw-")
 
 
 # ---------------------------------------------------------------------------
@@ -598,33 +568,37 @@ async def _handle_remote_control(command: str, chat_jid: str, msg: NewMessage) -
 
 async def main() -> None:
     """Entry point for the NanoClaw orchestrator."""
-    global _transport, _queue
+    global _transport, _queue, _runtime, _executor
 
-    _ensure_container_system_running()
+    await _ensure_container_system_running()
     init_database()
     logger.info("Database initialized")
     _load_state()
     restore_remote_control()
 
-    # Connect to NATS for IPC
     _transport = NatsTransport(NATS_URL)
     try:
         await _transport.connect()
     except ConnectionError:
         logger.critical(
-            "Failed to connect to NATS — is it running?",
+            "Failed to connect to NATS -- is it running?",
             url=NATS_URL,
             hint="docker compose -f docker-compose.dev.yml up -d",
         )
         sys.exit(1)
 
-    # Create queue with transport
-    _queue = GroupQueue(transport=_transport)
+    assert _runtime is not None
+    _executor = ContainerAgentExecutor(
+        CLAUDE_CODE_BACKEND,
+        _runtime,
+        _transport,
+        lambda: _registered_groups,
+    )
 
-    # Start credential proxy (containers route API calls through this)
+    _queue = GroupQueue(transport=_transport, runtime=_runtime)
+
     proxy_runner = await start_credential_proxy(CREDENTIAL_PROXY_PORT, PROXY_BIND_HOST)
 
-    # Graceful shutdown
     shutdown_event = asyncio.Event()
 
     def _signal_handler(sig_name: str) -> None:
@@ -635,7 +609,6 @@ async def main() -> None:
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, _signal_handler, sig.name)
 
-    # Import channel registry (triggers self-registration)
     import nanoclaw.channels  # noqa: F401
     from nanoclaw.channels.registry import (
         ChannelOpts,
@@ -643,7 +616,6 @@ async def main() -> None:
         get_registered_channel_names,
     )
 
-    # Channel callbacks (shared by all channels)
     def _on_message(chat_jid: str, msg: NewMessage) -> None:
         trimmed = msg.content.strip()
         if trimmed in ("/remote-control", "/remote-control-end"):
@@ -656,7 +628,6 @@ async def main() -> None:
             )
             return
 
-        # Sender allowlist drop mode
         if not msg.is_from_me and not msg.is_bot_message and chat_jid in _registered_groups:
             cfg = load_sender_allowlist()
             if should_drop_message(chat_jid, cfg) and not is_sender_allowed(chat_jid, msg.sender, cfg):
@@ -672,7 +643,6 @@ async def main() -> None:
         registered_groups=lambda: _registered_groups,
     )
 
-    # Create and connect all registered channels
     for channel_name in get_registered_channel_names():
         factory = get_channel_factory(channel_name)
         if factory is None:
@@ -691,20 +661,16 @@ async def main() -> None:
         logger.critical("No channels connected")
         sys.exit(1)
 
-    # Start subsystems
     start_scheduler_loop(_SchedulerDepsImpl())
 
-    # Start NATS IPC subscriptions (replaces file-based IPC watcher)
     ipc_deps = _IpcDepsImpl()
     ipc_tasks = await _start_nats_ipc_subscriptions(_transport, ipc_deps)
 
     _queue.set_process_messages_fn(_process_group_messages)
     _recover_pending_messages()
 
-    # Run message loop until shutdown
     await _message_loop(shutdown_event)
 
-    # Cleanup
     for t in ipc_tasks:
         t.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -715,6 +681,7 @@ async def main() -> None:
     for ch in _channels:
         await ch.disconnect()
     await _transport.close()
+    await _runtime.close()
 
 
 # ---------------------------------------------------------------------------
@@ -738,7 +705,7 @@ class _SchedulerDepsImpl:
     def on_process(
         self,
         group_jid: str,
-        proc: object,
+        proc: ContainerHandle,
         container_name: str,
         group_folder: str,
         job_id: str | None = None,
@@ -748,6 +715,10 @@ class _SchedulerDepsImpl:
     @property
     def transport(self) -> NatsTransport | None:
         return _transport
+
+    @property
+    def executor(self) -> ContainerAgentExecutor | None:
+        return _executor
 
     async def send_message(self, jid: str, raw_text: str) -> None:
         channel = find_channel(_channels, jid)

--- a/py/src/nanoclaw/main.py
+++ b/py/src/nanoclaw/main.py
@@ -12,8 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-from nanoclaw.agent import CLAUDE_CODE_BACKEND, AgentInput, AgentOutput
-from nanoclaw.agent.container_executor import ContainerAgentExecutor
+from nanoclaw.agent import CLAUDE_CODE_BACKEND, AgentInput, AgentOutput, ContainerAgentExecutor
 from nanoclaw.container.runner import (
     AvailableGroup,
     write_groups_snapshot,

--- a/py/src/nanoclaw/orchestration/task_scheduler.py
+++ b/py/src/nanoclaw/orchestration/task_scheduler.py
@@ -16,12 +16,8 @@ if TYPE_CHECKING:
 
 from croniter import croniter
 
-from nanoclaw.container.runner import (
-    ContainerInput,
-    ContainerOutput,
-    run_container_agent,
-    write_tasks_snapshot,
-)
+from nanoclaw.agent import AgentInput, AgentOutput
+from nanoclaw.container.runner import write_tasks_snapshot
 from nanoclaw.core.config import ASSISTANT_NAME, SCHEDULER_POLL_INTERVAL
 from nanoclaw.core.group_folder import resolve_group_folder_path
 from nanoclaw.core.logger import get_logger
@@ -36,8 +32,8 @@ from nanoclaw.db.sqlite import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
-
+    from nanoclaw.agent.container_executor import ContainerAgentExecutor
+    from nanoclaw.container.runtime import ContainerHandle
     from nanoclaw.container.scheduler import GroupQueue
     from nanoclaw.ipc.nats_transport import NatsTransport
 
@@ -66,12 +62,9 @@ def compute_next_run(task: ScheduledTask) -> str | None:
             ms = 0
 
         if ms <= 0:
-            # Guard against malformed interval that would cause an infinite loop
             logger.warning("Invalid interval value", task_id=task.id, value=task.schedule_value)
             return datetime.fromtimestamp(now + 60.0, tz=UTC).isoformat()
 
-        # Anchor to the scheduled time, not now, to prevent drift.
-        # Skip past any missed intervals so we always land in the future.
         assert task.next_run is not None
         next_ts = datetime.fromisoformat(task.next_run).timestamp() + ms / 1000.0
         while next_ts <= now:
@@ -91,7 +84,7 @@ class SchedulerDependencies(Protocol):
     def on_process(
         self,
         group_jid: str,
-        proc: object,
+        proc: ContainerHandle,
         container_name: str,
         group_folder: str,
         job_id: str | None = None,
@@ -99,6 +92,8 @@ class SchedulerDependencies(Protocol):
     def send_message(self, jid: str, text: str) -> Awaitable[None]: ...
     @property
     def transport(self) -> NatsTransport | None: ...
+    @property
+    def executor(self) -> ContainerAgentExecutor | None: ...
 
 
 _TASK_CLOSE_DELAY_S: float = 10.0
@@ -110,13 +105,11 @@ async def _run_task(
 ) -> None:
     """Run a single scheduled task in a container."""
     start_time = time.monotonic()
-    time.time()
 
     try:
         group_dir = resolve_group_folder_path(task.group_folder)
     except ValueError as exc:
         err_msg = str(exc)
-        # Stop retry churn for malformed legacy rows.
         update_task(task.id, status="paused")
         logger.error("Task has invalid group folder", task_id=task.id, group_folder=task.group_folder, error=err_msg)
         log_task_run(
@@ -152,7 +145,21 @@ async def _run_task(
         )
         return
 
-    # Update tasks snapshot in NATS KV for container to read (Channel 6)
+    executor = deps.executor
+    if executor is None:
+        logger.error("Agent executor not available for task", task_id=task.id)
+        log_task_run(
+            TaskRunLog(
+                task_id=task.id,
+                run_at=datetime.now(UTC).isoformat(),
+                duration_ms=int((time.monotonic() - start_time) * 1000),
+                status="error",
+                result=None,
+                error="Agent executor not initialized",
+            )
+        )
+        return
+
     is_main = group.is_main
     transport = deps.transport
     if transport is not None:
@@ -178,17 +185,15 @@ async def _run_task(
     result: str | None = None
     error: str | None = None
 
-    # For group context mode, use the group's current session
     sessions = deps.get_sessions()
     session_id = sessions.get(task.group_folder) if task.context_mode == "group" else None
 
-    # After the task produces a result, close the container promptly.
     close_handle: asyncio.TimerHandle | None = None
 
     def _schedule_close() -> None:
         nonlocal close_handle
         if close_handle is not None:
-            return  # already scheduled
+            return
         loop = asyncio.get_running_loop()
         close_handle = loop.call_later(
             _TASK_CLOSE_DELAY_S,
@@ -197,7 +202,7 @@ async def _run_task(
 
     try:
 
-        async def _on_output(streamed_output: ContainerOutput) -> None:
+        async def _on_output(streamed_output: AgentOutput) -> None:
             nonlocal result, error
             if streamed_output.result:
                 result = streamed_output.result
@@ -209,9 +214,8 @@ async def _run_task(
             if streamed_output.status == "error":
                 error = streamed_output.error or "Unknown error"
 
-        output = await run_container_agent(
-            group,
-            ContainerInput(
+        output = await executor.execute(
+            AgentInput(
                 prompt=task.prompt,
                 session_id=session_id,
                 group_folder=task.group_folder,
@@ -220,11 +224,10 @@ async def _run_task(
                 is_scheduled_task=True,
                 assistant_name=ASSISTANT_NAME,
             ),
-            lambda proc, container_name, job_id: deps.on_process(
-                task.chat_jid, proc, container_name, task.group_folder, job_id
+            lambda handle, container_name, job_id: deps.on_process(
+                task.chat_jid, handle, container_name, task.group_folder, job_id
             ),
             _on_output,
-            transport=transport,
         )
 
         if close_handle is not None:
@@ -289,7 +292,6 @@ def start_scheduler_loop(deps: SchedulerDependencies) -> asyncio.Task[None]:
                     logger.info("Found due tasks", count=len(due_tasks))
 
                 for task in due_tasks:
-                    # Re-check task status in case it was paused/cancelled
                     current_task = get_task_by_id(task.id)
                     if not current_task or current_task.status != "active":
                         continue

--- a/py/tests/agent/test_executor.py
+++ b/py/tests/agent/test_executor.py
@@ -1,0 +1,92 @@
+"""Tests for nanoclaw.agent.executor -- data types and backend configs."""
+
+from __future__ import annotations
+
+from nanoclaw.agent.executor import (
+    CLAUDE_CODE_BACKEND,
+    PIMONO_BACKEND,
+    AgentBackendConfig,
+    AgentInput,
+    AgentOutput,
+)
+
+
+def test_agent_input_frozen() -> None:
+    inp = AgentInput(prompt="hello", group_folder="g", chat_jid="j", is_main=True)
+    try:
+        inp.prompt = "other"  # type: ignore[misc]
+        raise AssertionError("Should have raised")
+    except AttributeError:
+        pass
+
+
+def test_agent_input_optional_fields() -> None:
+    inp = AgentInput(prompt="p", group_folder="g", chat_jid="j", is_main=False)
+    assert inp.session_id is None
+    assert inp.is_scheduled_task is False
+    assert inp.assistant_name is None
+    assert inp.system_prompt is None
+    assert inp.role_config is None
+
+
+def test_agent_input_all_fields() -> None:
+    inp = AgentInput(
+        prompt="hello",
+        group_folder="grp",
+        chat_jid="jid",
+        is_main=True,
+        session_id="s1",
+        is_scheduled_task=True,
+        assistant_name="Andy",
+        system_prompt="You are helpful",
+        role_config={"role": "coder"},
+    )
+    assert inp.prompt == "hello"
+    assert inp.system_prompt == "You are helpful"
+    assert inp.role_config == {"role": "coder"}
+
+
+def test_agent_output_frozen() -> None:
+    out = AgentOutput(status="success", result="done")
+    try:
+        out.status = "error"  # type: ignore[misc]
+        raise AssertionError("Should have raised")
+    except AttributeError:
+        pass
+
+
+def test_agent_output_optional_fields() -> None:
+    out = AgentOutput(status="success", result=None)
+    assert out.new_session_id is None
+    assert out.error is None
+
+
+def test_agent_backend_config_defaults() -> None:
+    cfg = AgentBackendConfig(name="test", image="test:latest")
+    assert cfg.entrypoint is None
+    assert cfg.extra_mounts == []
+    assert cfg.extra_env == {}
+    assert cfg.skip_claude_session is False
+
+
+def test_claude_code_backend_preset() -> None:
+    assert CLAUDE_CODE_BACKEND.name == "claude-code"
+    assert CLAUDE_CODE_BACKEND.image == "nanoclaw-agent:latest"
+    assert CLAUDE_CODE_BACKEND.entrypoint is None
+    assert CLAUDE_CODE_BACKEND.skip_claude_session is False
+
+
+def test_pimono_backend_preset() -> None:
+    assert PIMONO_BACKEND.name == "pi-mono"
+    assert PIMONO_BACKEND.image == "ppi-agent:latest"
+    assert PIMONO_BACKEND.entrypoint == ["python", "-m", "ppi.coding_agent", "--mode", "nanoclaw"]
+    assert PIMONO_BACKEND.skip_claude_session is True
+
+
+def test_agent_backend_config_frozen() -> None:
+    cfg = AgentBackendConfig(name="t", image="i")
+    try:
+        cfg.name = "other"  # type: ignore[misc]
+        raise AssertionError("Should have raised")
+    except AttributeError:
+        pass

--- a/py/tests/container/test_docker_runtime.py
+++ b/py/tests/container/test_docker_runtime.py
@@ -1,0 +1,246 @@
+"""Tests for nanoclaw.container.docker_runtime -- DockerRuntime with mocked aiodocker."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nanoclaw.container.docker_runtime import (
+    DockerContainerHandle,
+    DockerRuntime,
+    _mounts_to_binds,
+    _parse_memory,
+)
+from nanoclaw.container.runtime import ContainerSpec, VolumeMount
+
+# ---------------------------------------------------------------------------
+# Unit helpers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_memory_bytes() -> None:
+    assert _parse_memory("1024") == 1024
+
+
+def test_parse_memory_k() -> None:
+    assert _parse_memory("512k") == 512 * 1024
+
+
+def test_parse_memory_m() -> None:
+    assert _parse_memory("256m") == 256 * 1024**2
+
+
+def test_parse_memory_g() -> None:
+    assert _parse_memory("2g") == 2 * 1024**3
+
+
+def test_mounts_to_binds() -> None:
+    mounts = [
+        VolumeMount(host_path="/a", container_path="/b", readonly=True),
+        VolumeMount(host_path="/c", container_path="/d", readonly=False),
+    ]
+    result = _mounts_to_binds(mounts)
+    assert result == ["/a:/b:ro", "/c:/d:rw"]
+
+
+# ---------------------------------------------------------------------------
+# DockerContainerHandle
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_container() -> MagicMock:
+    container = MagicMock()
+    container.wait = AsyncMock(return_value={"StatusCode": 0})
+    container.stop = AsyncMock()
+    container.delete = AsyncMock()
+    return container
+
+
+async def test_handle_name() -> None:
+    container = _make_mock_container()
+    handle = DockerContainerHandle(container, "test-container")
+    assert handle.name == "test-container"
+
+
+async def test_handle_pid() -> None:
+    container = _make_mock_container()
+    handle = DockerContainerHandle(container, "test-container")
+    assert isinstance(handle.pid, int)
+    assert handle.pid >= 0
+
+
+async def test_handle_wait_success() -> None:
+    container = _make_mock_container()
+    handle = DockerContainerHandle(container, "test")
+    code = await handle.wait()
+    assert code == 0
+
+
+async def test_handle_wait_error() -> None:
+    container = _make_mock_container()
+    container.wait = AsyncMock(return_value={"StatusCode": 1})
+    handle = DockerContainerHandle(container, "test")
+    code = await handle.wait()
+    assert code == 1
+
+
+async def test_handle_stop() -> None:
+    container = _make_mock_container()
+    handle = DockerContainerHandle(container, "test")
+    await handle.stop(timeout=5)
+    container.stop.assert_awaited_once_with(t=5)
+    container.delete.assert_awaited_once_with(force=True)
+
+
+# ---------------------------------------------------------------------------
+# DockerRuntime
+# ---------------------------------------------------------------------------
+
+
+async def test_runtime_name() -> None:
+    rt = DockerRuntime()
+    assert rt.name == "docker"
+
+
+async def test_ensure_available_success() -> None:
+    rt = DockerRuntime()
+    mock_docker = MagicMock()
+    mock_docker.system = MagicMock()
+    mock_docker.system.info = AsyncMock()
+    mock_docker.close = AsyncMock()
+
+    with patch("nanoclaw.container.docker_runtime.aiodocker.Docker", return_value=mock_docker):
+        await rt.ensure_available()
+    assert rt._client is not None
+
+
+async def test_ensure_available_failure() -> None:
+    rt = DockerRuntime()
+    mock_docker = MagicMock()
+    mock_docker.system = MagicMock()
+    mock_docker.system.info = AsyncMock(side_effect=OSError("not running"))
+    mock_docker.close = AsyncMock()
+
+    with (
+        patch("nanoclaw.container.docker_runtime.aiodocker.Docker", return_value=mock_docker),
+        pytest.raises(RuntimeError, match="Docker daemon"),
+    ):
+        await rt.ensure_available()
+    assert rt._client is None
+
+
+async def test_run_creates_and_starts() -> None:
+    rt = DockerRuntime()
+    mock_container = _make_mock_container()
+    mock_container.start = AsyncMock()
+
+    mock_client = MagicMock()
+    mock_client.containers = MagicMock()
+    import aiodocker.exceptions
+
+    mock_client.containers.container = MagicMock(
+        side_effect=aiodocker.exceptions.DockerError(404, "not found")
+    )
+    mock_client.containers.create_or_replace = AsyncMock(return_value=mock_container)
+    rt._client = mock_client
+
+    spec = ContainerSpec(
+        name="test-run",
+        image="test:latest",
+        env={"FOO": "bar"},
+    )
+    handle = await rt.run(spec)
+    assert handle.name == "test-run"
+    mock_container.start.assert_awaited_once()
+
+
+async def test_stop_idempotent() -> None:
+    rt = DockerRuntime()
+    mock_container = _make_mock_container()
+
+    mock_client = MagicMock()
+    mock_client.containers = MagicMock()
+    mock_client.containers.container = MagicMock(return_value=mock_container)
+    rt._client = mock_client
+
+    await rt.stop("test-stop")
+    mock_container.stop.assert_awaited_once()
+    mock_container.delete.assert_awaited_once()
+
+
+async def test_cleanup_orphans() -> None:
+    rt = DockerRuntime()
+
+    mock_c1 = MagicMock()
+    mock_c1._container = {"Names": ["/nanoclaw-test-1"]}
+
+    mock_client = MagicMock()
+    mock_client.containers = MagicMock()
+    mock_client.containers.list = AsyncMock(return_value=[mock_c1])
+
+    # Mock stop to be a no-op
+    mock_stopped = _make_mock_container()
+    mock_client.containers.container = MagicMock(return_value=mock_stopped)
+    rt._client = mock_client
+
+    removed = await rt.cleanup_orphans("nanoclaw-")
+    assert removed == ["nanoclaw-test-1"]
+
+
+async def test_close() -> None:
+    rt = DockerRuntime()
+    mock_client = MagicMock()
+    mock_client.close = AsyncMock()
+    rt._client = mock_client
+
+    await rt.close()
+    mock_client.close.assert_awaited_once()
+    assert rt._client is None
+
+
+async def test_close_no_client() -> None:
+    rt = DockerRuntime()
+    await rt.close()  # Should not raise
+
+
+def test_spec_to_config_basic() -> None:
+    spec = ContainerSpec(
+        name="test",
+        image="img:latest",
+        env={"K": "V"},
+    )
+    config: dict[str, Any] = DockerRuntime._spec_to_config(spec)
+    assert config["Image"] == "img:latest"
+    assert "K=V" in config["Env"]
+
+
+def test_spec_to_config_user() -> None:
+    spec = ContainerSpec(name="test", image="img", user="1000:1000")
+    config: dict[str, Any] = DockerRuntime._spec_to_config(spec)
+    assert config["User"] == "1000:1000"
+
+
+def test_spec_to_config_entrypoint() -> None:
+    spec = ContainerSpec(name="test", image="img", entrypoint=["python", "-m", "app"])
+    config: dict[str, Any] = DockerRuntime._spec_to_config(spec)
+    assert config["Entrypoint"] == ["python", "-m", "app"]
+
+
+def test_spec_to_config_memory() -> None:
+    spec = ContainerSpec(name="test", image="img", memory_limit="512m")
+    config: dict[str, Any] = DockerRuntime._spec_to_config(spec)
+    assert config["HostConfig"]["Memory"] == 512 * 1024**2
+
+
+def test_spec_to_config_cpu() -> None:
+    spec = ContainerSpec(name="test", image="img", cpu_limit=1.5)
+    config: dict[str, Any] = DockerRuntime._spec_to_config(spec)
+    assert config["HostConfig"]["NanoCpus"] == int(1.5e9)
+
+
+def test_spec_to_config_extra_hosts() -> None:
+    spec = ContainerSpec(name="test", image="img", extra_hosts={"host.docker.internal": "host-gateway"})
+    config: dict[str, Any] = DockerRuntime._spec_to_config(spec)
+    assert "host.docker.internal:host-gateway" in config["HostConfig"]["ExtraHosts"]

--- a/py/tests/container/test_runner.py
+++ b/py/tests/container/test_runner.py
@@ -1,0 +1,134 @@
+"""Tests for nanoclaw.container.runner -- pure functions."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from nanoclaw.agent.executor import AgentBackendConfig
+from nanoclaw.container.runner import (
+    AvailableGroup,
+    ContainerInput,
+    ContainerOutput,
+    build_container_spec,
+    build_volume_mounts,
+)
+from nanoclaw.container.runtime import VolumeMount
+from nanoclaw.core.types import RegisteredGroup
+
+
+def _make_group(folder: str = "test-group", is_main: bool = False) -> RegisteredGroup:
+    return RegisteredGroup(
+        name="Test Group",
+        folder=folder,
+        trigger="@Andy",
+        added_at="2024-01-01",
+        is_main=is_main,
+    )
+
+
+class TestBuildVolumeMounts:
+    def test_non_main_has_group_folder(self, tmp_path: object) -> None:
+        group = _make_group()
+        with (
+            patch("nanoclaw.container.runner.resolve_group_folder_path", return_value=tmp_path),
+            patch("nanoclaw.container.runner.GROUPS_DIR", tmp_path),
+            patch("nanoclaw.container.runner.PROJECT_ROOT", tmp_path),
+        ):
+            mounts = build_volume_mounts(group, is_main=False)
+        container_paths = [m.container_path for m in mounts]
+        assert "/workspace/group" in container_paths
+
+    def test_main_has_project_and_group(self, tmp_path: object) -> None:
+        group = _make_group(is_main=True)
+        with (
+            patch("nanoclaw.container.runner.resolve_group_folder_path", return_value=tmp_path),
+            patch("nanoclaw.container.runner.GROUPS_DIR", tmp_path),
+            patch("nanoclaw.container.runner.PROJECT_ROOT", tmp_path),
+        ):
+            mounts = build_volume_mounts(group, is_main=True)
+        container_paths = [m.container_path for m in mounts]
+        assert "/workspace/project" in container_paths
+        assert "/workspace/group" in container_paths
+
+    def test_backend_config_skip_claude_session(self, tmp_path: object) -> None:
+        group = _make_group()
+        config = AgentBackendConfig(name="test", image="test:latest", skip_claude_session=True)
+        with (
+            patch("nanoclaw.container.runner.resolve_group_folder_path", return_value=tmp_path),
+            patch("nanoclaw.container.runner.GROUPS_DIR", tmp_path),
+            patch("nanoclaw.container.runner.PROJECT_ROOT", tmp_path),
+        ):
+            mounts = build_volume_mounts(group, is_main=False, backend_config=config)
+        container_paths = [m.container_path for m in mounts]
+        assert not any(".claude" in p for p in container_paths)
+
+    def test_backend_config_extra_mounts(self, tmp_path: object) -> None:
+        group = _make_group()
+        config = AgentBackendConfig(
+            name="test",
+            image="test:latest",
+            extra_mounts=[("/extra/host", "/extra/container", True)],
+        )
+        with (
+            patch("nanoclaw.container.runner.resolve_group_folder_path", return_value=tmp_path),
+            patch("nanoclaw.container.runner.GROUPS_DIR", tmp_path),
+            patch("nanoclaw.container.runner.PROJECT_ROOT", tmp_path),
+        ):
+            mounts = build_volume_mounts(group, is_main=False, backend_config=config)
+        container_paths = [m.container_path for m in mounts]
+        assert "/extra/container" in container_paths
+
+
+class TestBuildContainerSpec:
+    def test_basic_spec(self) -> None:
+        mounts = [VolumeMount(host_path="/a", container_path="/b", readonly=True)]
+        with patch("nanoclaw.container.runner.detect_auth_mode", return_value="api-key"):
+            spec = build_container_spec(mounts, "test-container", "job-123")
+        assert spec.name == "test-container"
+        assert spec.image == "nanoclaw-agent:latest"
+        assert "JOB_ID" in spec.env
+        assert spec.env["JOB_ID"] == "job-123"
+        assert "ANTHROPIC_API_KEY" in spec.env
+
+    def test_spec_with_backend_config(self) -> None:
+        mounts = [VolumeMount(host_path="/a", container_path="/b", readonly=False)]
+        config = AgentBackendConfig(
+            name="pi-mono",
+            image="ppi:latest",
+            entrypoint=["python", "-m", "ppi"],
+            extra_env={"CUSTOM_VAR": "value"},
+        )
+        with patch("nanoclaw.container.runner.detect_auth_mode", return_value="oauth"):
+            spec = build_container_spec(mounts, "test-ppi", "job-456", backend_config=config)
+        assert spec.image == "ppi:latest"
+        assert spec.entrypoint == ["python", "-m", "ppi"]
+        assert spec.env["CUSTOM_VAR"] == "value"
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in spec.env
+
+    def test_spec_env_has_nats_url(self) -> None:
+        with patch("nanoclaw.container.runner.detect_auth_mode", return_value="api-key"):
+            spec = build_container_spec([], "c", "j")
+        assert "NATS_URL" in spec.env
+        assert "host.docker.internal" in spec.env["NATS_URL"]
+
+
+class TestBackwardCompatAliases:
+    def test_container_input_is_agent_input(self) -> None:
+        from nanoclaw.agent.executor import AgentInput
+
+        assert ContainerInput is AgentInput
+
+    def test_container_output_is_agent_output(self) -> None:
+        from nanoclaw.agent.executor import AgentOutput
+
+        assert ContainerOutput is AgentOutput
+
+
+class TestAvailableGroup:
+    def test_available_group_frozen(self) -> None:
+        g = AvailableGroup(jid="j", name="n", last_activity="2024-01-01", is_registered=True)
+        try:
+            g.jid = "other"  # type: ignore[misc]
+            raise AssertionError("Should have raised")
+        except AttributeError:
+            pass

--- a/py/tests/container/test_runtime.py
+++ b/py/tests/container/test_runtime.py
@@ -1,29 +1,67 @@
-"""Tests for nanoclaw.container_runtime."""
+"""Tests for nanoclaw.container.runtime -- Protocol types and factory."""
+
+from __future__ import annotations
+
+import pytest
 
 from nanoclaw.container.runtime import (
     CONTAINER_HOST_GATEWAY,
-    CONTAINER_RUNTIME_BIN,
-    host_gateway_args,
-    readonly_mount_args,
-    stop_container,
+    ContainerSpec,
+    VolumeMount,
+    get_host_gateway_extra_hosts,
+    get_runtime,
 )
 
 
-def test_constants() -> None:
-    assert CONTAINER_RUNTIME_BIN == "docker"
+def test_container_host_gateway() -> None:
     assert CONTAINER_HOST_GATEWAY == "host.docker.internal"
 
 
-def test_host_gateway_args() -> None:
-    args = host_gateway_args()
-    assert isinstance(args, list)
+def test_volume_mount_frozen() -> None:
+    m = VolumeMount(host_path="/a", container_path="/b", readonly=True)
+    try:
+        m.host_path = "/c"  # type: ignore[misc]
+        raise AssertionError("Should have raised")
+    except AttributeError:
+        pass
 
 
-def test_readonly_mount_args() -> None:
-    args = readonly_mount_args("/host/path", "/container/path")
-    assert args == ["-v", "/host/path:/container/path:ro"]
+def test_container_spec_defaults() -> None:
+    spec = ContainerSpec(name="test", image="test:latest")
+    assert spec.mounts == []
+    assert spec.env == {}
+    assert spec.user is None
+    assert spec.memory_limit is None
+    assert spec.cpu_limit is None
+    assert spec.extra_hosts == {}
+    assert spec.remove_on_exit is True
+    assert spec.entrypoint is None
 
 
-def test_stop_container() -> None:
-    cmd = stop_container("nanoclaw-test")
-    assert cmd == "docker stop -t 1 nanoclaw-test"
+def test_container_spec_frozen() -> None:
+    spec = ContainerSpec(name="test", image="test:latest")
+    try:
+        spec.name = "other"  # type: ignore[misc]
+        raise AssertionError("Should have raised")
+    except AttributeError:
+        pass
+
+
+def test_get_host_gateway_extra_hosts() -> None:
+    result = get_host_gateway_extra_hosts()
+    assert isinstance(result, dict)
+
+
+def test_get_runtime_docker() -> None:
+    rt = get_runtime("docker")
+    assert rt.name == "docker"
+
+
+def test_get_runtime_k8s_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        get_runtime("k8s")
+
+
+def test_get_runtime_unknown() -> None:
+    with pytest.raises(ValueError, match="Unknown container runtime"):
+        get_runtime("podman")

--- a/py/tests/ipc/test_protocol.py
+++ b/py/tests/ipc/test_protocol.py
@@ -15,6 +15,8 @@ def test_agent_init_data_roundtrip() -> None:
         session_id="sess-001",
         is_scheduled_task=False,
         assistant_name="Andy",
+        system_prompt="Be helpful",
+        role_config={"role": "coder"},
     )
     data = init.serialize()
     restored = AgentInitData.deserialize(data)
@@ -25,6 +27,8 @@ def test_agent_init_data_roundtrip() -> None:
     assert restored.session_id == init.session_id
     assert restored.is_scheduled_task == init.is_scheduled_task
     assert restored.assistant_name == init.assistant_name
+    assert restored.system_prompt == init.system_prompt
+    assert restored.role_config == init.role_config
 
 
 def test_agent_init_data_optional_fields() -> None:
@@ -40,6 +44,8 @@ def test_agent_init_data_optional_fields() -> None:
     assert restored.session_id is None
     assert restored.is_scheduled_task is False
     assert restored.assistant_name is None
+    assert restored.system_prompt is None
+    assert restored.role_config is None
 
 
 def test_agent_init_data_frozen() -> None:

--- a/py/tests/test_e2e.py
+++ b/py/tests/test_e2e.py
@@ -1,6 +1,6 @@
 """End-to-end tests for the NanoClaw Python runtime engine.
 
-Strategy: Mock Docker (run_container_agent), test real logic.
+Strategy: Mock AgentExecutor, test real logic.
 Uses in-memory SQLite, real GroupQueue, real message routing.
 """
 
@@ -96,41 +96,70 @@ def e2e_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 # ---------------------------------------------------------------------------
 
 
-def make_container_mock(
-    response_text: str = "Hello from the agent!",
-    new_session_id: str | None = "sess-001",
-    status: str = "success",
-    error: str | None = None,
-) -> Callable[..., Awaitable[object]]:
-    """Create a mock for run_container_agent that simulates container execution."""
-    from nanoclaw.container.runner import ContainerOutput
+class _FakeHandle:
+    """Minimal ContainerHandle for tests."""
 
-    captured_inputs: list[object] = []
+    @property
+    def name(self) -> str:
+        return "test-container-mock"
 
-    async def mock_run_container_agent(
-        group: object,
+    @property
+    def pid(self) -> int:
+        return 12345
+
+
+class MockExecutor:
+    """Mock AgentExecutor that captures inputs and returns canned outputs."""
+
+    def __init__(
+        self,
+        response_text: str = "Hello from the agent!",
+        new_session_id: str | None = "sess-001",
+        status: str = "success",
+        error: str | None = None,
+    ) -> None:
+        self._response_text = response_text
+        self._new_session_id = new_session_id
+        self._status = status
+        self._error = error
+        self.captured_inputs: list[object] = []
+
+    @property
+    def name(self) -> str:
+        return "mock"
+
+    async def execute(
+        self,
         inp: object,
         on_process: Callable[..., None],
         on_output: Callable[..., Awaitable[None]] | None = None,
-        transport: object | None = None,
-    ) -> ContainerOutput:
-        captured_inputs.append(inp)
-        on_process(object(), "test-container-mock", "test-job")
+    ) -> object:
+        from nanoclaw.agent import AgentOutput
 
-        output = ContainerOutput(
-            status=status,  # type: ignore[arg-type]
-            result=response_text if status == "success" else None,
-            new_session_id=new_session_id,
-            error=error,
+        self.captured_inputs.append(inp)
+        on_process(_FakeHandle(), "test-container-mock", "test-job")
+
+        output = AgentOutput(
+            status=self._status,  # type: ignore[arg-type]
+            result=self._response_text if self._status == "success" else None,
+            new_session_id=self._new_session_id,
+            error=self._error,
         )
 
         if on_output is not None:
             await on_output(output)
 
-        return ContainerOutput(status="success", result=None, new_session_id=new_session_id)
+        return AgentOutput(status="success", result=None, new_session_id=self._new_session_id)
 
-    mock_run_container_agent.captured_inputs = captured_inputs  # type: ignore[attr-defined]
-    return mock_run_container_agent  # type: ignore[return-value]
+
+def make_container_mock(
+    response_text: str = "Hello from the agent!",
+    new_session_id: str | None = "sess-001",
+    status: str = "success",
+    error: str | None = None,
+) -> MockExecutor:
+    """Create a MockExecutor that simulates container execution."""
+    return MockExecutor(response_text=response_text, new_session_id=new_session_id, status=status, error=error)
 
 
 # ---------------------------------------------------------------------------
@@ -216,10 +245,10 @@ async def test_message_inbound_to_response(e2e_env: Path) -> None:
 
     mock_agent = make_container_mock(response_text="It's sunny today!")
 
-    with patch("nanoclaw.main.run_container_agent", mock_agent):
-        import nanoclaw.main as m
+    import nanoclaw.main as m
 
-        result = await m._process_group_messages("chat@test")
+    m._executor = mock_agent  # type: ignore[assignment]
+    result = await m._process_group_messages("chat@test")
 
     assert result is True
     assert len(channel.sent) == 1
@@ -238,14 +267,14 @@ async def test_trigger_pattern_required(e2e_env: Path) -> None:
 
     mock_agent = make_container_mock()
 
-    with patch("nanoclaw.main.run_container_agent", mock_agent):
-        import nanoclaw.main as m
+    import nanoclaw.main as m
 
-        result = await m._process_group_messages("group@test")
+    m._executor = mock_agent  # type: ignore[assignment]
+    result = await m._process_group_messages("group@test")
 
     assert result is True
     assert len(channel.sent) == 0  # No response sent
-    assert len(mock_agent.captured_inputs) == 0  # type: ignore[attr-defined]
+    assert len(mock_agent.captured_inputs) == 0
 
 
 async def test_trigger_pattern_activates(e2e_env: Path) -> None:
@@ -258,10 +287,10 @@ async def test_trigger_pattern_activates(e2e_env: Path) -> None:
 
     mock_agent = make_container_mock(response_text="It's 3pm")
 
-    with patch("nanoclaw.main.run_container_agent", mock_agent):
-        import nanoclaw.main as m
+    import nanoclaw.main as m
 
-        result = await m._process_group_messages("group@test")
+    m._executor = mock_agent  # type: ignore[assignment]
+    result = await m._process_group_messages("group@test")
 
     assert result is True
     assert len(channel.sent) == 1
@@ -278,10 +307,10 @@ async def test_session_persistence(e2e_env: Path) -> None:
 
     mock_agent = make_container_mock(response_text="Got it", new_session_id="sess-abc-123")
 
-    with patch("nanoclaw.main.run_container_agent", mock_agent):
-        import nanoclaw.main as m
+    import nanoclaw.main as m
 
-        await m._process_group_messages("chat@test")
+    m._executor = mock_agent  # type: ignore[assignment]
+    await m._process_group_messages("chat@test")
 
     # Session should be persisted
     assert m._sessions.get("testgroup") == "sess-abc-123"
@@ -301,10 +330,10 @@ async def test_error_rollback(e2e_env: Path) -> None:
 
     mock_agent = make_container_mock(status="error", error="Container crashed", response_text="")
 
-    with patch("nanoclaw.main.run_container_agent", mock_agent):
-        import nanoclaw.main as m
+    import nanoclaw.main as m
 
-        result = await m._process_group_messages("chat@test")
+    m._executor = mock_agent  # type: ignore[assignment]
+    result = await m._process_group_messages("chat@test")
 
     assert result is False  # Signal retry
     # Cursor should be rolled back (empty or previous value)
@@ -321,10 +350,10 @@ async def test_internal_tags_stripped(e2e_env: Path) -> None:
 
     mock_agent = make_container_mock(response_text="Visible text <internal>hidden reasoning</internal> more visible")
 
-    with patch("nanoclaw.main.run_container_agent", mock_agent):
-        import nanoclaw.main as m
+    import nanoclaw.main as m
 
-        await m._process_group_messages("chat@test")
+    m._executor = mock_agent  # type: ignore[assignment]
+    await m._process_group_messages("chat@test")
 
     assert len(channel.sent) == 1
     assert "hidden reasoning" not in channel.sent[0][1]
@@ -342,10 +371,10 @@ async def test_typing_indicator(e2e_env: Path) -> None:
 
     mock_agent = make_container_mock(response_text="Hi there")
 
-    with patch("nanoclaw.main.run_container_agent", mock_agent):
-        import nanoclaw.main as m
+    import nanoclaw.main as m
 
-        await m._process_group_messages("chat@test")
+    m._executor = mock_agent  # type: ignore[assignment]
+    await m._process_group_messages("chat@test")
 
     # Should have typing=True then typing=False
     assert ("chat@test", True) in channel.typing_events
@@ -362,25 +391,32 @@ async def test_format_messages_xml(e2e_env: Path) -> None:
 
     captured_prompts: list[str] = []
 
-    from nanoclaw.container.runner import ContainerInput, ContainerOutput
+    from nanoclaw.agent import AgentInput, AgentOutput
 
-    async def capturing_mock(
-        group: object,
-        inp: ContainerInput,
-        on_process: Callable[..., None],
-        on_output: Callable[..., Awaitable[None]] | None = None,
-        transport: object | None = None,
-    ) -> ContainerOutput:
-        captured_prompts.append(inp.prompt)
-        on_process(object(), "test-container", "test-job")
-        if on_output:
-            await on_output(ContainerOutput(status="success", result="OK"))
-        return ContainerOutput(status="success", result=None)
+    class CapturingExecutor:
+        """Mock executor that captures prompts."""
 
-    with patch("nanoclaw.main.run_container_agent", capturing_mock):
-        import nanoclaw.main as m
+        @property
+        def name(self) -> str:
+            return "capturing-mock"
 
-        await m._process_group_messages("chat@test")
+        async def execute(
+            self,
+            inp: AgentInput,
+            on_process: Callable[..., None],
+            on_output: Callable[..., Awaitable[None]] | None = None,
+        ) -> AgentOutput:
+            captured_prompts.append(inp.prompt)
+            on_process(_FakeHandle(), "test-container", "test-job")
+            output = AgentOutput(status="success", result="OK")
+            if on_output:
+                await on_output(output)
+            return AgentOutput(status="success", result=None)
+
+    import nanoclaw.main as m
+
+    m._executor = CapturingExecutor()  # type: ignore[assignment]
+    await m._process_group_messages("chat@test")
 
     assert len(captured_prompts) == 1
     prompt = captured_prompts[0]

--- a/py/tests/test_user_flow.py
+++ b/py/tests/test_user_flow.py
@@ -176,34 +176,49 @@ def send_user_message(
 def make_agent_mock(
     response: str = "Hello! I'm Andy, your assistant.",
     session_id: str | None = "session-001",
-) -> Callable[..., Awaitable[object]]:
-    """Mock container agent that returns a canned response."""
-    from nanoclaw.container.runner import ContainerOutput
+) -> object:
+    """Mock agent executor that returns a canned response.
 
-    captured: list[object] = []
+    Returns an object satisfying the AgentExecutor protocol with a ``name``
+    property and an async ``execute`` method.  Also exposes a
+    ``captured_inputs`` list so tests can inspect what was passed in.
+    """
+    from nanoclaw.agent.executor import AgentInput, AgentOutput
 
-    async def mock_run(
-        group: object,
-        inp: object,
-        on_process: Callable[..., None],
-        on_output: Callable[..., Awaitable[None]] | None = None,
-        transport: object | None = None,
-    ) -> ContainerOutput:
-        captured.append(inp)
-        on_process(object(), "mock-container", "test-job")
+    class _FakeHandle:
+        """Minimal stand-in for ContainerHandle."""
 
-        output = ContainerOutput(
-            status="success",
-            result=response,
-            new_session_id=session_id,
-        )
-        if on_output:
-            await on_output(output)
+        name: str = "mock-container"
+        pid: int = 12345
 
-        return ContainerOutput(status="success", result=None, new_session_id=session_id)
+    class MockExecutor:
+        def __init__(self) -> None:
+            self.captured_inputs: list[AgentInput] = []
 
-    mock_run.captured = captured  # type: ignore[attr-defined]
-    return mock_run  # type: ignore[return-value]
+        @property
+        def name(self) -> str:
+            return "mock"
+
+        async def execute(
+            self,
+            inp: AgentInput,
+            on_process: Callable[..., None],
+            on_output: Callable[..., Awaitable[None]] | None = None,
+        ) -> AgentOutput:
+            self.captured_inputs.append(inp)
+            on_process(_FakeHandle(), "mock-container", "test-job")
+
+            output = AgentOutput(
+                status="success",
+                result=response,
+                new_session_id=session_id,
+            )
+            if on_output:
+                await on_output(output)
+
+            return AgentOutput(status="success", result=None, new_session_id=session_id)
+
+    return MockExecutor()
 
 
 # ===========================================================================
@@ -235,10 +250,10 @@ class TestScenarioFirstTimeUser:
         # Mock the container agent
         mock = make_agent_mock(response="Of course! What do you need help with?")
 
-        with patch("nanoclaw.main.run_container_agent", mock):
-            import nanoclaw.main as m
+        import nanoclaw.main as m
 
-            result = await m._process_group_messages(jid)
+        m._executor = mock  # type: ignore[assignment]
+        result = await m._process_group_messages(jid)
 
         assert result is True
         assert len(channel.sent) == 1
@@ -258,10 +273,10 @@ class TestScenarioFirstTimeUser:
         send_user_message(jid, "Remember this context")
         mock = make_agent_mock(response="Noted!", session_id="sess-abc-123")
 
-        with patch("nanoclaw.main.run_container_agent", mock):
-            import nanoclaw.main as m
+        import nanoclaw.main as m
 
-            await m._process_group_messages(jid)
+        m._executor = mock  # type: ignore[assignment]
+        await m._process_group_messages(jid)
 
         assert m._sessions.get("telegram_mygroup") == "sess-abc-123"
 
@@ -316,10 +331,10 @@ class TestScenarioMessageFormatting:
             response="Here's the summary. <internal>I checked CLAUDE.md for context</internal> The project is going well!"
         )
 
-        with patch("nanoclaw.main.run_container_agent", mock):
-            import nanoclaw.main as m
+        import nanoclaw.main as m
 
-            await m._process_group_messages(jid)
+        m._executor = mock  # type: ignore[assignment]
+        await m._process_group_messages(jid)
 
         assert len(channel.sent) == 1
         assert "I checked CLAUDE.md" not in channel.sent[0][1]
@@ -346,14 +361,14 @@ class TestScenarioTriggerPattern:
         send_user_message(jid, "Just chatting among ourselves")
         mock = make_agent_mock()
 
-        with patch("nanoclaw.main.run_container_agent", mock):
-            import nanoclaw.main as m
+        import nanoclaw.main as m
 
-            result = await m._process_group_messages(jid)
+        m._executor = mock  # type: ignore[assignment]
+        result = await m._process_group_messages(jid)
 
         assert result is True
         assert len(channel.sent) == 0  # No response
-        assert len(mock.captured) == 0  # Agent never called
+        assert len(mock.captured_inputs) == 0  # Agent never called
 
     async def test_trigger_activates_agent(self, env: Path) -> None:
         """Message with @Andy in non-main group → agent invoked."""
@@ -371,10 +386,10 @@ class TestScenarioTriggerPattern:
         send_user_message(jid, "@Andy what's the status of the deploy?")
         mock = make_agent_mock(response="Deploy is at 95%, almost done!")
 
-        with patch("nanoclaw.main.run_container_agent", mock):
-            import nanoclaw.main as m
+        import nanoclaw.main as m
 
-            result = await m._process_group_messages(jid)
+        m._executor = mock  # type: ignore[assignment]
+        result = await m._process_group_messages(jid)
 
         assert result is True
         assert len(channel.sent) == 1
@@ -627,7 +642,7 @@ class TestScenarioErrorRecovery:
 
     async def test_error_rolls_back_cursor(self, env: Path) -> None:
         """Container error → message cursor rolled back → retry possible."""
-        from nanoclaw.container.runner import ContainerOutput
+        from nanoclaw.agent.executor import AgentInput, AgentOutput
 
         jid = "tg_group_123@telegram"
         channel = FakeChannel(owned_jids=[jid])
@@ -635,22 +650,30 @@ class TestScenarioErrorRecovery:
 
         send_user_message(jid, "This will crash the agent")
 
-        async def failing_agent(
-            group: object,
-            inp: object,
-            on_process: Callable[..., None],
-            on_output: Callable[..., Awaitable[None]] | None = None,
-            transport: object | None = None,
-        ) -> ContainerOutput:
-            on_process(object(), "crash-container", "test-job")
-            if on_output:
-                await on_output(ContainerOutput(status="error", result=None, error="Segfault"))
-            return ContainerOutput(status="error", result=None, error="Segfault")
+        class _FakeHandle:
+            name: str = "crash-container"
+            pid: int = 99999
 
-        with patch("nanoclaw.main.run_container_agent", failing_agent):
-            import nanoclaw.main as m
+        class FailingExecutor:
+            @property
+            def name(self) -> str:
+                return "mock"
 
-            result = await m._process_group_messages(jid)
+            async def execute(
+                self,
+                inp: AgentInput,
+                on_process: Callable[..., None],
+                on_output: Callable[..., Awaitable[None]] | None = None,
+            ) -> AgentOutput:
+                on_process(_FakeHandle(), "crash-container", "test-job")
+                if on_output:
+                    await on_output(AgentOutput(status="error", result=None, error="Segfault"))
+                return AgentOutput(status="error", result=None, error="Segfault")
+
+        import nanoclaw.main as m
+
+        m._executor = FailingExecutor()  # type: ignore[assignment]
+        result = await m._process_group_messages(jid)
 
         # Error → rollback → retry
         assert result is False
@@ -658,7 +681,7 @@ class TestScenarioErrorRecovery:
 
     async def test_partial_output_prevents_rollback(self, env: Path) -> None:
         """If agent already sent output before error → no rollback (prevent duplicates)."""
-        from nanoclaw.container.runner import ContainerOutput
+        from nanoclaw.agent.executor import AgentInput, AgentOutput
 
         jid = "tg_group_123@telegram"
         channel = FakeChannel(owned_jids=[jid])
@@ -666,31 +689,39 @@ class TestScenarioErrorRecovery:
 
         send_user_message(jid, "Start answering then crash")
 
-        async def partial_then_error(
-            group: object,
-            inp: object,
-            on_process: Callable[..., None],
-            on_output: Callable[..., Awaitable[None]] | None = None,
-            transport: object | None = None,
-        ) -> ContainerOutput:
-            on_process(object(), "partial-container", "test-job")
-            if on_output:
-                # First: send a successful partial output
-                await on_output(
-                    ContainerOutput(
-                        status="success",
-                        result="Here's part of the answer...",
-                        new_session_id=None,
+        class _FakeHandle:
+            name: str = "partial-container"
+            pid: int = 99998
+
+        class PartialThenErrorExecutor:
+            @property
+            def name(self) -> str:
+                return "mock"
+
+            async def execute(
+                self,
+                inp: AgentInput,
+                on_process: Callable[..., None],
+                on_output: Callable[..., Awaitable[None]] | None = None,
+            ) -> AgentOutput:
+                on_process(_FakeHandle(), "partial-container", "test-job")
+                if on_output:
+                    # First: send a successful partial output
+                    await on_output(
+                        AgentOutput(
+                            status="success",
+                            result="Here's part of the answer...",
+                            new_session_id=None,
+                        )
                     )
-                )
-                # Then: error
-                await on_output(ContainerOutput(status="error", result=None, error="Timeout"))
-            return ContainerOutput(status="error", result=None, error="Timeout")
+                    # Then: error
+                    await on_output(AgentOutput(status="error", result=None, error="Timeout"))
+                return AgentOutput(status="error", result=None, error="Timeout")
 
-        with patch("nanoclaw.main.run_container_agent", partial_then_error):
-            import nanoclaw.main as m
+        import nanoclaw.main as m
 
-            result = await m._process_group_messages(jid)
+        m._executor = PartialThenErrorExecutor()  # type: ignore[assignment]
+        result = await m._process_group_messages(jid)
 
         # Partial output was sent → no rollback → returns True
         assert result is True
@@ -905,10 +936,10 @@ class TestScenarioEndToEndFlow:
             session_id="sess-turn-1",
         )
 
-        with patch("nanoclaw.main.run_container_agent", mock1):
-            import nanoclaw.main as m
+        import nanoclaw.main as m
 
-            result1 = await m._process_group_messages(jid)
+        m._executor = mock1  # type: ignore[assignment]
+        result1 = await m._process_group_messages(jid)
 
         assert result1 is True
         assert len(channel.sent) == 1
@@ -931,8 +962,8 @@ class TestScenarioEndToEndFlow:
 
         channel.sent.clear()
 
-        with patch("nanoclaw.main.run_container_agent", mock2):
-            result2 = await m._process_group_messages(jid)
+        m._executor = mock2  # type: ignore[assignment]
+        result2 = await m._process_group_messages(jid)
 
         assert result2 is True
         assert len(channel.sent) == 1
@@ -942,8 +973,8 @@ class TestScenarioEndToEndFlow:
         assert m._sessions.get("telegram_mygroup") == "sess-turn-2"
 
         # Verify the agent received the prompt with message history
-        assert len(mock2.captured) == 1  # type: ignore[attr-defined]
-        inp = mock2.captured[0]  # type: ignore[attr-defined]
+        assert len(mock2.captured_inputs) == 1  # type: ignore[attr-defined]
+        inp = mock2.captured_inputs[0]  # type: ignore[attr-defined]
         assert hasattr(inp, "prompt")
         assert "break that down" in inp.prompt  # type: ignore[union-attr]
 

--- a/py/uv.lock
+++ b/py/uv.lock
@@ -7,6 +7,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiodocker"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/64/3b724f650cedc6d5c1cad7fdae3dd3b53c976d075547ff5268e2f1e56db5/aiodocker-0.26.0.tar.gz", hash = "sha256:7e4ee40c6f98e6d1cf95d712f15aef3853087c0475bc7ea5ec499c2d485ba7ec", size = 162018, upload-time = "2026-02-17T18:53:23.234Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/0d/e8f4164cbd950195900dd77aad23136f9ddc7feb0fb478d71839d1fda573/aiodocker-0.26.0-py3-none-any.whl", hash = "sha256:f450acf0b402a03c6a6f1517d06bdff739c404e62578b332182ca272fde6e986", size = 47825, upload-time = "2026-02-17T18:53:22.088Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -599,8 +611,10 @@ name = "nanoclaw"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiodocker" },
     { name = "aiohttp" },
     { name = "croniter" },
+    { name = "nats-py" },
     { name = "python-telegram-bot" },
     { name = "slack-bolt" },
     { name = "structlog" },
@@ -622,9 +636,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiodocker", specifier = ">=0.23" },
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "croniter", specifier = ">=2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
+    { name = "nats-py", specifier = ">=2.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -637,6 +653,15 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-croniter", specifier = ">=6.2.2.20260316" }]
+
+[[package]]
+name = "nats-py"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f8/b956c4621ba88748ed707c52e69f95b7a50c8914e750edca59a5bef84a76/nats_py-2.14.0.tar.gz", hash = "sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed", size = 120751, upload-time = "2026-02-23T22:44:58.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl", hash = "sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d", size = 82259, upload-time = "2026-02-23T22:45:00.152Z" },
+]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary

- **Layer 1 — ContainerRuntime**: `ContainerSpec`, `ContainerHandle`, `ContainerRuntime` protocols + `DockerRuntime` using `aiodocker` (replaces all `subprocess docker` calls)
- **Layer 2 — AgentExecutor**: `AgentInput`/`AgentOutput`/`AgentBackendConfig` types + `ContainerAgentExecutor` (replaces `run_container_agent()` function)
- **runner.py** reduced from ~685 → ~250 lines (pure spec-building functions only)
- Preset backend configs: `CLAUDE_CODE_BACKEND`, `PIMONO_BACKEND` — switching backend is a one-line config change
- `AgentInitData` gains `system_prompt` and `role_config` fields for multi-role support
- **No `subprocess docker` calls remain** in the codebase

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `mypy --strict src/nanoclaw` — no issues found in 35 source files
- [x] `pytest --cov --cov-fail-under=80` — 183 passed, 85% coverage
- [x] New tests: `test_executor.py`, `test_docker_runtime.py`, `test_runner.py` (build_volume_mounts, build_container_spec)
- [x] Updated tests: `test_runtime.py`, `test_protocol.py`, `test_e2e.py`, `test_user_flow.py`
- [x] Verified no subprocess docker calls remain via grep

Closes #6